### PR TITLE
Bump substrate-interface to 1.7.9

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 termcolor
-substrate-interface==1.7.5
+substrate-interface~=1.7.9
 password_strength
 cryptography~=42.0.5
 ansible~=6.7


### PR DESCRIPTION
Bumps py-substrate-interface to ~=1.7.9 to keep inline bittensor staging.