### PR TITLE
bump up cryptography version until 43.0.1

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,7 +2,7 @@ termcolor
 eth-utils<2.3.0
 substrate-interface~=1.7.9
 password_strength
-cryptography~=42.0.5
+cryptography~=43.0.1
 ansible~=6.7
 ansible_vault~=2.1
 munch~=2.5.0


### PR DESCRIPTION
Fix for

```
pyca/cryptography's wheels include a statically linked copy of OpenSSL. The versions of OpenSSL included in cryptography 37.0.0-43.0.0 are vulnerable to a security issue. More details about the vulnerability itself can be found in https://openssl-library.org/news/secadv/20240903.txt.

If you are building cryptography source ("sdist") then you are responsible for upgrading your copy of OpenSSL. Only users installing from wheels built by the cryptography project (i.e., those distributed on PyPI) need to update their cryptography versions.
```