### PR TITLE
Add the ability to use local variables to store hot/coldkey passwords

### DIFF
--- a/bittensor_wallet/keyfile/__init__.py
+++ b/bittensor_wallet/keyfile/__init__.py
@@ -11,7 +11,9 @@ keyfile_data_is_encrypted_legacy = _.keyfile_data_is_encrypted_legacy
 keyfile_data_is_encrypted = _.keyfile_data_is_encrypted
 keyfile_data_encryption_method = _.keyfile_data_encryption_method
 legacy_encrypt_keyfile_data = _.legacy_encrypt_keyfile_data
-get_coldkey_password_from_environment = _.get_coldkey_password_from_environment
+get_coldkey_password_from_environment = _.get_password_from_environment
+# backwards compatibility
+get_password_from_environment = get_coldkey_password_from_environment
 encrypt_keyfile_data = _.encrypt_keyfile_data
 decrypt_keyfile_data = _.decrypt_keyfile_data
 Keyfile = _.Keyfile

--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -1086,7 +1086,7 @@ impl Keyfile {
     }
 
     /// Removes the password associated with the Keyfile from the local environment.
-    fn delete_password_from_env(&self) -> PyResult<bool> {
+    fn remove_password_from_env(&self) -> PyResult<bool> {
         let env_var_name = self.env_var_name()?;
 
         if env::var(&env_var_name).is_ok() {

--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -175,7 +175,7 @@ pub fn validate_password(_py: Python, password: &str) -> PyResult<bool> {
             Ok(false)
         }
     } else {
-        utils::print("Password not strong enough. Try increasing the length of the password or the password complexity.".to_string());
+        utils::print("Password not strong enough. Try increasing the length of the password or the password complexity.\n".to_string());
         Ok(false)
     }
 }
@@ -305,7 +305,7 @@ pub fn legacy_encrypt_keyfile_data(
         // function to get password from user
         ask_password(py, true).unwrap());
 
-    utils::print(":exclamation_mark: Encrypting key with legacy encryption method...".to_string());
+    utils::print(":exclamation_mark: Encrypting key with legacy encryption method...\n".to_string());
 
     // Encrypting key with legacy encryption method
     let encrypted_data = encrypt_vault(keyfile_data, password.as_str())
@@ -750,21 +750,21 @@ impl Keyfile {
     ) -> PyResult<bool> {
         if !self.exists_on_device()? {
             if print_result {
-                utils::print(format!("Keyfile does not exist. {}", self.path));
+                utils::print(format!("Keyfile '{}' does not exist.\n", self.path));
             }
             return Ok(false);
         }
 
         if !self.is_readable()? {
             if print_result {
-                utils::print(format!("Keyfile is not readable. {}", self.path));
+                utils::print(format!("Keyfile '{}' is not readable.\n", self.path));
             }
             return Ok(false);
         }
 
         if !self.is_writable()? {
             if print_result {
-                utils::print(format!("Keyfile is not writable. {}", self.path));
+                utils::print(format!("Keyfile '{}' is not writable.\n", self.path));
             }
             return Ok(false);
         }
@@ -779,7 +779,7 @@ impl Keyfile {
             if keyfile_data_is_encrypted(py, keyfile_data_bytes)?
                 && !keyfile_data_is_encrypted_nacl(py, keyfile_data_bytes)?
             {
-                utils::print("You may update the keyfile to improve security...".to_string());
+                utils::print("You may update the keyfile to improve security...\n".to_string());
 
                 // ask user for the confirmation for updating
                 if update_keyfile == confirm_prompt("Update keyfile?") {
@@ -788,7 +788,7 @@ impl Keyfile {
                     // check mnemonic if saved
                     while !stored_mnemonic {
                         utils::print(
-                            "Please store your mnemonic in case an error occurs...".to_string(),
+                            "Please store your mnemonic in case an error occurs...\n".to_string(),
                         );
                         if confirm_prompt("Have you stored the mnemonic?") {
                             stored_mnemonic = true;
@@ -844,17 +844,17 @@ impl Keyfile {
 
             return if !keyfile_data_is_encrypted(py, keyfile_data_bytes)? {
                 if print_result {
-                    utils::print("Keyfile is not encrypted.".to_string());
+                    utils::print("Keyfile is not encrypted.\n".to_string());
                 }
                 Ok(false)
             } else if keyfile_data_is_encrypted_nacl(py, keyfile_data_bytes)? {
                 if print_result {
-                    utils::print("Keyfile is updated.".to_string());
+                    utils::print("Keyfile is updated.\n".to_string());
                 }
                 Ok(true)
             } else {
                 if print_result {
-                    utils::print("Keyfile is outdated, please update using 'btcli'.".to_string());
+                    utils::print("Keyfile is outdated, please update using 'btcli'.\n".to_string());
                 }
                 Ok(false)
             };

--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -576,6 +576,11 @@ impl Keyfile {
         self._read_keyfile_data_from_file(py)
     }
 
+    #[getter]
+    pub fn env_var(&self, _py: Python) -> PyResult<String> {
+        Ok(format!("BT_PW_{}", self.path.clone().replace(std::path::MAIN_SEPARATOR, "_").replace(".", "_").to_uppercase()))
+    }
+
     /// Writes the keypair to the file and optionally encrypts data.
     #[pyo3(signature = (keypair, encrypt = true, overwrite = false, password = None))]
     pub fn set_keypair(

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -587,7 +587,6 @@ impl Keypair {
     }
 }
 
-
 // Default values for Keypair
 impl Default for Keypair {
     fn default() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ fn register_keyfile_module(main_module: &Bound<'_, PyModule>) -> PyResult<()> {
         &keyfile_module
     )?)?;
     keyfile_module.add_function(wrap_pyfunction!(
-        keyfile::get_coldkey_password_from_environment,
+        keyfile::get_password_from_environment,
         &keyfile_module
     )?)?;
     keyfile_module.add_function(wrap_pyfunction!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,12 +115,16 @@ pub fn print(s: String) {
     Python::with_gil(|py| {
         let locals = PyDict::new_bound(py);
         locals.set_item("s", s).unwrap();
-        py.run_bound(r#"
+        py.run_bound(
+            r#"
 import sys
 print(s, end='')
 sys.stdout.flush()
-"#, None, Some(&locals))
-            .unwrap();
+"#,
+            None,
+            Some(&locals),
+        )
+        .unwrap();
     });
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,7 +115,11 @@ pub fn print(s: String) {
     Python::with_gil(|py| {
         let locals = PyDict::new_bound(py);
         locals.set_item("s", s).unwrap();
-        py.run_bound("print(s, end='')", None, Some(&locals))
+        py.run_bound(r#"
+import sys
+print(s, end='')
+sys.stdout.flush()
+"#, None, Some(&locals))
             .unwrap();
     });
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -20,7 +20,7 @@ type PyRuntimeError = KeyFileError;
 #[pyfunction]
 #[pyo3(signature = (mnemonic, key_type))]
 pub fn display_mnemonic_msg(mnemonic: String, key_type: &str) {
-    utils::print(format!("{}", "\nIMPORTANT: Store this mnemonic in a secure (preferable offline place), as anyone who has possession of this mnemonic can use it to regenerate the key and access your tokens.".red()));
+    utils::print(format!("{}", "\nIMPORTANT: Store this mnemonic in a secure (preferable offline place), as anyone who has possession of this mnemonic can use it to regenerate the key and access your tokens.\n".red()));
 
     utils::print(format!(
         "\nThe mnemonic to the new {} is: {}",

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -243,7 +243,7 @@ except argparse.ArgumentError:
 
         Keyfile::new(
             hotkey_path.to_string_lossy().into_owned(),
-            Some(self.name.clone()),
+            Some(self.hotkey.clone()),
         )
     }
 
@@ -262,7 +262,7 @@ except argparse.ArgumentError:
 
         Keyfile::new(
             coldkey_path.to_string_lossy().into_owned(),
-            Some(self.name.clone()),
+            Some("coldkey".to_string()),
         )
     }
 
@@ -281,7 +281,7 @@ except argparse.ArgumentError:
 
         Keyfile::new(
             coldkeypub_path.to_string_lossy().into_owned(),
-            Some(self.name.clone()),
+            Some("coldkeypub.txt".parse()?),
         )
     }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -172,45 +172,65 @@ except argparse.ArgumentError:
     }
 
     /// Checks for existing coldkeypub and hotkeys, and creates them if non-existent.
-    #[pyo3(signature = (coldkey_use_password=true, hotkey_use_password=false, save_coldkey_to_env=false, save_hotkey_to_env=true))]
+    #[pyo3(signature = (coldkey_use_password=true, hotkey_use_password=false, save_coldkey_to_env=false, save_hotkey_to_env=false, coldkey_password=None, hotkey_password=None, overwrite=false, suppress=false))]
     pub fn create_if_non_existent(
         &mut self,
         coldkey_use_password: bool,
         hotkey_use_password: bool,
         save_coldkey_to_env: bool,
         save_hotkey_to_env: bool,
+        coldkey_password: Option<String>,
+        hotkey_password: Option<String>,
+        overwrite: bool,
+        suppress: bool,
         py: Python,
     ) -> PyResult<Wallet> {
-        self.create(coldkey_use_password, hotkey_use_password, save_coldkey_to_env, save_hotkey_to_env, py)
+        self.create(coldkey_use_password, hotkey_use_password, save_coldkey_to_env, save_hotkey_to_env, coldkey_password, hotkey_password, overwrite, suppress, py)
     }
 
     /// Checks for existing coldkeypub and hotkeys, and creates them if non-existent.
+    ///     Arguments:
+    ///         coldkey_use_password (bool): Whether to use a password for coldkey. Defaults to ``True``.
+    ///         hotkey_use_password (bool): Whether to use a password for hotkey. Defaults to ``False``.
+    ///         save_coldkey_to_env (bool): Whether to save a coldkey password to local env. Defaults to ``False``.
+    ///         save_hotkey_to_env (bool): Whether to save a hotkey password to local env. Defaults to ``False``.
+    ///         coldkey_password (Optional[str]): Coldkey password for encryption. Defaults to ``None``. If `coldkey_password` is passed, then `coldkey_use_password` is automatically ``True``.
+    ///         hotkey_password (Optional[str]): Hotkey password for encryption. Defaults to ``None``. If `hotkey_password` is passed, then `hotkey_use_password` is automatically ``True``.
+    ///         overwrite (bool): Whether to overwrite an existing keys. Defaults to ``False``.
+    ///         suppress (bool): If ``True``, suppresses the display of the keys mnemonic message. Defaults to ``False``.
+    ///
+    ///     Returns:
+    ///         Wallet instance with created keys.
     #[allow(clippy::bool_comparison)]
-    #[pyo3(signature = (coldkey_use_password=true, hotkey_use_password=false, save_coldkey_to_env=false, save_hotkey_to_env=true))]
+    #[pyo3(signature = (coldkey_use_password=true, hotkey_use_password=false, save_coldkey_to_env=false, save_hotkey_to_env=false, coldkey_password=None, hotkey_password=None, overwrite=false, suppress=false))]
     pub fn create(
         &mut self,
         coldkey_use_password: bool,
         hotkey_use_password: bool,
         save_coldkey_to_env: bool,
         save_hotkey_to_env: bool,
+        coldkey_password: Option<String>,
+        hotkey_password: Option<String>,
+        overwrite: bool,
+        suppress: bool,
         py: Python,
     ) -> PyResult<Self> {
-        if self.coldkey_file()?.exists_on_device()? == false
+        if overwrite || self.coldkey_file()?.exists_on_device()? == false
             && self.coldkeypub_file()?.exists_on_device()? == false
         {
-            self.create_new_coldkey(12, coldkey_use_password, false, false, save_coldkey_to_env, py)?;
+            self.create_new_coldkey(12, coldkey_use_password, overwrite, suppress, save_coldkey_to_env, coldkey_password, py)?;
         } else {
             utils::print(format!(
-                "ColdKey for the wallet '{}' already exists.",
+                "ColdKey for the wallet '{}' already exists.\n",
                 self.name
             ));
         }
 
-        if !self.hotkey_file()?.exists_on_device()? {
-            self.create_new_hotkey(12, hotkey_use_password, false, false, py)?;
+        if overwrite || !self.hotkey_file()?.exists_on_device()? {
+            self.create_new_hotkey(12, hotkey_use_password, overwrite, suppress, save_hotkey_to_env, hotkey_password, py)?;
         } else {
             utils::print(format!(
-                "HotKey for the wallet '{}' already exists.",
+                "HotKey for the wallet '{}' already exists.\n",
                 self.name
             ));
         }
@@ -218,24 +238,49 @@ except argparse.ArgumentError:
         Ok(self.clone())
     }
 
-    /// Checks for existing coldkeypub and hotkeys and creates them if non-existent.
-    #[pyo3(signature = (coldkey_use_password=true, hotkey_use_password=false, save_coldkey_to_env=false))]
+    /// Checks for existing coldkeypub and hotkeys, and recreates them if non-existent.
+    ///
+    ///     Arguments:
+    ///         coldkey_use_password (bool): Whether to use a password for coldkey. Defaults to ``True``.
+    ///         hotkey_use_password (bool): Whether to use a password for hotkey. Defaults to ``False``.
+    ///         save_coldkey_to_env (bool): Whether to save a coldkey password to local env. Defaults to ``False``.
+    ///         save_hotkey_to_env (bool): Whether to save a hotkey password to local env. Defaults to ``False``.
+    ///         coldkey_password (Optional[str]): Coldkey password for encryption. Defaults to ``None``. If `coldkey_password` is passed, then `coldkey_use_password` is automatically ``True``.
+    ///         hotkey_password (Optional[str]): Hotkey password for encryption. Defaults to ``None``. If `hotkey_password` is passed, then `hotkey_use_password` is automatically ``True``.
+    ///         overwrite (bool): Whether to overwrite an existing keys. Defaults to ``False``.
+    ///         suppress (bool): If ``True``, suppresses the display of the keys mnemonic message. Defaults to ``False``.
+    ///
+    ///     Returns:
+    ///         Wallet instance with created keys.
+    #[pyo3(signature = (coldkey_use_password=true, hotkey_use_password=false, save_coldkey_to_env=false, save_hotkey_to_env=false, coldkey_password=None, hotkey_password=None, overwrite=false, suppress=false))]
     pub fn recreate(
         &mut self,
         coldkey_use_password: bool,
         hotkey_use_password: bool,
         save_coldkey_to_env: bool,
+        save_hotkey_to_env: bool,
+        coldkey_password: Option<String>,
+        hotkey_password: Option<String>,
+        overwrite: bool,
+        suppress: bool,
         py: Python,
     ) -> PyResult<Wallet> {
-        self.create_new_coldkey(12, coldkey_use_password, false, false, save_coldkey_to_env, py)?;
-        self.create_new_hotkey(12, hotkey_use_password, false, false, py)?;
+        self.create_new_coldkey(12, coldkey_use_password, overwrite, suppress, save_coldkey_to_env, coldkey_password, py)?;
+        self.create_new_hotkey(12, hotkey_use_password, overwrite, suppress, save_hotkey_to_env, hotkey_password, py)?;
 
         Ok(self.clone())
     }
 
+
     /// Property that returns the hotkey file.
     #[getter]
     pub fn hotkey_file(&self) -> PyResult<Keyfile> {
+        self.create_hotkey_file(false)
+    }
+
+    /// Created Hot Keyfile for Keypair
+    #[pyo3(signature = (save_hotkey_to_env=false))]
+    pub fn create_hotkey_file(&self, save_hotkey_to_env: bool) -> PyResult<Keyfile> {
         // get home dir
         let home = home_dir()
             .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("Failed to get user home directory."))?;
@@ -249,12 +294,19 @@ except argparse.ArgumentError:
         Keyfile::new(
             hotkey_path.to_string_lossy().into_owned(),
             Some(self.hotkey.clone()),
+            save_hotkey_to_env
         )
     }
 
     /// Property that returns the coldkey file.
     #[getter]
     pub fn coldkey_file(&self) -> PyResult<Keyfile> {
+        self.create_coldkey_file(false)
+    }
+
+    /// Created Cold Keyfile for Keypair
+    #[pyo3(signature = (save_coldkey_to_env=false))]
+    pub fn create_coldkey_file(&self, save_coldkey_to_env: bool) -> PyResult<Keyfile> {
         // get home dir
         let home = home_dir()
             .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("Failed to get user home directory."))?;
@@ -264,10 +316,10 @@ except argparse.ArgumentError:
 
         // concatenate coldkey path
         let coldkey_path = wallet_path.join("coldkey");
-
         Keyfile::new(
             coldkey_path.to_string_lossy().into_owned(),
             Some("coldkey".to_string()),
+            save_coldkey_to_env,
         )
     }
 
@@ -287,6 +339,7 @@ except argparse.ArgumentError:
         Keyfile::new(
             coldkeypub_path.to_string_lossy().into_owned(),
             Some("coldkeypub.txt".parse()?),
+            false,
         )
     }
 
@@ -335,18 +388,19 @@ except argparse.ArgumentError:
     }
 
     /// Sets the hotkey for the wallet.
-    #[pyo3(signature = (keypair, encrypt=true, overwrite=false, save_coldkey_to_env=false))]
+    #[pyo3(signature = (keypair, encrypt=true, overwrite=false, save_coldkey_to_env=false, coldkey_password=None))]
     pub fn set_coldkey(
         &mut self,
         keypair: Keypair,
         encrypt: bool,
         overwrite: bool,
         save_coldkey_to_env: bool,
+        coldkey_password: Option<String>,
         py: Python,
     ) -> PyResult<()> {
         self._coldkey = Some(keypair.clone());
-        self.coldkey_file()?
-            .set_keypair(keypair, encrypt, overwrite, None, py)
+        self.create_coldkey_file(save_coldkey_to_env)?
+            .set_keypair(keypair, encrypt, overwrite, coldkey_password, py)
     }
 
     /// Sets the coldkeypub for the wallet.
@@ -372,17 +426,19 @@ except argparse.ArgumentError:
     }
 
     /// Sets the hotkey for the wallet.
-    #[pyo3(signature = (keypair, encrypt=false, overwrite=false))]
+    #[pyo3(signature = (keypair, encrypt=false, overwrite=false, save_hotkey_to_env=false, hotkey_password=None))]
     pub fn set_hotkey(
         &mut self,
         keypair: Keypair,
         encrypt: bool,
         overwrite: bool,
+        save_hotkey_to_env: bool,
+        hotkey_password: Option<String>,
         py: Python,
     ) -> PyResult<()> {
         self._hotkey = Some(keypair.clone());
-        self.hotkey_file()?
-            .set_keypair(keypair.clone(), encrypt, overwrite, None, py)
+        self.create_hotkey_file(save_hotkey_to_env)?
+            .set_keypair(keypair.clone(), encrypt, overwrite, hotkey_password, py)
     }
 
     /// Gets the coldkey from the wallet.
@@ -404,7 +460,7 @@ except argparse.ArgumentError:
     }
 
     /// Creates coldkey from uri string, optionally encrypts it with the user-provided password.
-    #[pyo3(signature = (uri, use_password = true, overwrite = false, suppress = false, save_coldkey_to_env=false))]
+    #[pyo3(signature = (uri, use_password = true, overwrite = false, suppress = false, save_coldkey_to_env=false, coldkey_password=None))]
     pub fn create_coldkey_from_uri(
         &mut self,
         uri: String,
@@ -412,6 +468,7 @@ except argparse.ArgumentError:
         overwrite: bool,
         suppress: bool,
         save_coldkey_to_env: bool,
+        coldkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Wallet> {
         let keypair = Keypair::create_from_uri(uri.as_str())?;
@@ -422,19 +479,21 @@ except argparse.ArgumentError:
             }
         }
 
-        self.set_coldkey(keypair.clone(), use_password, overwrite, save_coldkey_to_env, py)?;
+        self.set_coldkey(keypair.clone(), use_password, overwrite, save_coldkey_to_env, coldkey_password, py)?;
         self.set_coldkeypub(keypair.clone(), false, overwrite, py)?;
         Ok(self.clone())
     }
 
     /// Creates hotkey from uri string, optionally encrypts it with the user-provided password.
-    #[pyo3(signature = (uri, use_password = true, overwrite = false, suppress = false))]
+    #[pyo3(signature = (uri, use_password = true, overwrite = false, suppress = false, save_hotkey_to_env=false, hotkey_password=None))]
     pub fn create_hotkey_from_uri(
         &mut self,
         uri: String,
         use_password: bool,
         overwrite: bool,
         suppress: bool,
+        save_hotkey_to_env: bool,
+        hotkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Wallet> {
         let keypair = Keypair::create_from_uri(uri.as_str())?;
@@ -445,7 +504,7 @@ except argparse.ArgumentError:
             }
         }
 
-        self.set_hotkey(keypair.clone(), use_password, overwrite, py)?;
+        self.set_hotkey(keypair.clone(), use_password, overwrite, save_hotkey_to_env, hotkey_password, py)?;
         Ok(self.clone())
     }
 
@@ -489,7 +548,7 @@ except argparse.ArgumentError:
     }
 
     /// Creates a new coldkey, optionally encrypts it with the user-provided password and saves to disk.
-    #[pyo3(signature = (n_words = 12, use_password=true, overwrite=false, suppress=false, save_coldkey_to_env=false))]
+    #[pyo3(signature = (n_words = 12, use_password=true, overwrite=false, suppress=false, save_coldkey_to_env=false, coldkey_password=None))]
     pub fn new_coldkey(
         &mut self,
         n_words: usize,
@@ -497,20 +556,22 @@ except argparse.ArgumentError:
         overwrite: bool,
         suppress: bool,
         save_coldkey_to_env: bool,
+        coldkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Wallet> {
-        self.create_new_coldkey(n_words, use_password, overwrite, suppress, save_coldkey_to_env, py)
+        self.create_new_coldkey(n_words, use_password, overwrite, suppress, save_coldkey_to_env, coldkey_password, py)
     }
 
     /// Creates a new coldkey, optionally encrypts it with the user-provided password and saves to disk.
-    #[pyo3(signature = (n_words=12, use_password=true, overwrite=false, suppress=false, save_coldkey_to_env=false))]
+    #[pyo3(signature = (n_words=12, use_password=true, overwrite=false, suppress=false, save_coldkey_to_env=false, coldkey_password=None))]
     fn create_new_coldkey(
         &mut self,
         n_words: usize,
-        use_password: bool,
+        mut use_password: bool,
         overwrite: bool,
         suppress: bool,
         save_coldkey_to_env: bool,
+        coldkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Wallet> {
         let mnemonic = Keypair::generate_mnemonic(n_words)?;
@@ -520,33 +581,44 @@ except argparse.ArgumentError:
             display_mnemonic_msg(mnemonic, "coldkey");
         }
 
-        self.set_coldkey(keypair.clone(), use_password, overwrite, save_coldkey_to_env, py)?;
+        // if coldkey_password is passed then coldkey_use_password always is true
+        use_password = if coldkey_password.is_some() {
+            true
+        } else {
+            use_password
+        };
+
+        self.set_coldkey(keypair.clone(), use_password, overwrite, save_coldkey_to_env, coldkey_password, py)?;
         self.set_coldkeypub(keypair.clone(), false, overwrite, py)?;
 
         Ok(self.clone())
     }
 
     /// Creates a new hotkey, optionally encrypts it with the user-provided password and saves to disk.
-    #[pyo3(signature = (n_words = 12, use_password = false, overwrite = false, suppress = false))]
+    #[pyo3(signature = (n_words = 12, use_password = false, overwrite = false, suppress = false, save_hotkey_to_env=false, hotkey_password=None))]
     pub fn new_hotkey(
         &mut self,
         n_words: usize,
         use_password: bool,
         overwrite: bool,
         suppress: bool,
+        save_hotkey_to_env: bool,
+        hotkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Wallet> {
-        self.create_new_hotkey(n_words, use_password, overwrite, suppress, py)
+        self.create_new_hotkey(n_words, use_password, overwrite, suppress, save_hotkey_to_env, hotkey_password, py)
     }
 
     /// Creates a new hotkey, optionally encrypts it with the user-provided password and saves to disk.
-    #[pyo3(signature = (n_words=12, use_password=false, overwrite=false, suppress=false))]
+    #[pyo3(signature = (n_words=12, use_password=false, overwrite=false, suppress=false, save_hotkey_to_env=false, hotkey_password=None))]
     pub fn create_new_hotkey(
         &mut self,
         n_words: usize,
-        use_password: bool,
+        mut use_password: bool,
         overwrite: bool,
         suppress: bool,
+        save_hotkey_to_env: bool,
+        hotkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Wallet> {
         let mnemonic = Keypair::generate_mnemonic(n_words)?;
@@ -556,7 +628,14 @@ except argparse.ArgumentError:
             display_mnemonic_msg(mnemonic, "hotkey");
         }
 
-        self.set_hotkey(keypair.clone(), use_password, overwrite, py)?;
+        // if hotkey_password is passed then hotkey_use_password always is true
+        use_password = if hotkey_password.is_some() {
+            true
+        } else {
+            use_password
+        };
+
+        self.set_hotkey(keypair.clone(), use_password, overwrite, save_hotkey_to_env, hotkey_password, py)?;
         Ok(self.clone())
     }
 
@@ -599,7 +678,7 @@ except argparse.ArgumentError:
 
     /// Regenerates the coldkey from the passed mnemonic or seed, or JSON encrypts it with the user's password and saves the file.
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (mnemonic=None, seed=None, json=None, use_password=true, overwrite=false, suppress=false, save_coldkey_to_env=false))]
+    #[pyo3(signature = (mnemonic=None, seed=None, json=None, use_password=true, overwrite=false, suppress=false, save_coldkey_to_env=false, coldkey_password=None))]
     pub fn regenerate_coldkey(
         &mut self,
         mnemonic: Option<String>,
@@ -609,6 +688,7 @@ except argparse.ArgumentError:
         overwrite: bool,
         suppress: bool,
         save_coldkey_to_env: bool,
+        coldkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Self> {
         let keypair = if let Some(mnemonic) = mnemonic {
@@ -631,14 +711,14 @@ except argparse.ArgumentError:
             ));
         };
 
-        self.set_coldkey(keypair.clone(), use_password, overwrite, save_coldkey_to_env, py)?;
+        self.set_coldkey(keypair.clone(), use_password, overwrite, save_coldkey_to_env, coldkey_password, py)?;
         self.set_coldkeypub(keypair.clone(), false, overwrite, py)?;
         Ok(self.clone())
     }
 
     /// Regenerates the hotkey from passed mnemonic or seed, encrypts it with the user's password and saves the file.
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (mnemonic=None, seed=None, json=None, use_password=true, overwrite=false, suppress=false))]
+    #[pyo3(signature = (mnemonic=None, seed=None, json=None, use_password=true, overwrite=false, suppress=false, save_hotkey_to_env=false, hotkey_password=None))]
     pub fn regenerate_hotkey(
         &mut self,
         mnemonic: Option<String>,
@@ -647,6 +727,8 @@ except argparse.ArgumentError:
         use_password: bool,
         overwrite: bool,
         suppress: bool,
+        save_hotkey_to_env: bool,
+        hotkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Self> {
         let keypair = if let Some(mnemonic) = mnemonic {
@@ -669,7 +751,7 @@ except argparse.ArgumentError:
             ));
         };
 
-        self.set_hotkey(keypair, use_password, overwrite, py)?;
+        self.set_hotkey(keypair, use_password, overwrite, save_hotkey_to_env, hotkey_password, py)?;
 
         Ok(self.clone())
     }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -185,7 +185,17 @@ except argparse.ArgumentError:
         suppress: bool,
         py: Python,
     ) -> PyResult<Wallet> {
-        self.create(coldkey_use_password, hotkey_use_password, save_coldkey_to_env, save_hotkey_to_env, coldkey_password, hotkey_password, overwrite, suppress, py)
+        self.create(
+            coldkey_use_password,
+            hotkey_use_password,
+            save_coldkey_to_env,
+            save_hotkey_to_env,
+            coldkey_password,
+            hotkey_password,
+            overwrite,
+            suppress,
+            py,
+        )
     }
 
     /// Checks for existing coldkeypub and hotkeys, and creates them if non-existent.
@@ -215,10 +225,19 @@ except argparse.ArgumentError:
         suppress: bool,
         py: Python,
     ) -> PyResult<Self> {
-        if overwrite || self.coldkey_file()?.exists_on_device()? == false
-            && self.coldkeypub_file()?.exists_on_device()? == false
+        if overwrite
+            || self.coldkey_file()?.exists_on_device()? == false
+                && self.coldkeypub_file()?.exists_on_device()? == false
         {
-            self.create_new_coldkey(12, coldkey_use_password, overwrite, suppress, save_coldkey_to_env, coldkey_password, py)?;
+            self.create_new_coldkey(
+                12,
+                coldkey_use_password,
+                overwrite,
+                suppress,
+                save_coldkey_to_env,
+                coldkey_password,
+                py,
+            )?;
         } else {
             utils::print(format!(
                 "ColdKey for the wallet '{}' already exists.\n",
@@ -227,7 +246,15 @@ except argparse.ArgumentError:
         }
 
         if overwrite || !self.hotkey_file()?.exists_on_device()? {
-            self.create_new_hotkey(12, hotkey_use_password, overwrite, suppress, save_hotkey_to_env, hotkey_password, py)?;
+            self.create_new_hotkey(
+                12,
+                hotkey_use_password,
+                overwrite,
+                suppress,
+                save_hotkey_to_env,
+                hotkey_password,
+                py,
+            )?;
         } else {
             utils::print(format!(
                 "HotKey for the wallet '{}' already exists.\n",
@@ -265,12 +292,27 @@ except argparse.ArgumentError:
         suppress: bool,
         py: Python,
     ) -> PyResult<Wallet> {
-        self.create_new_coldkey(12, coldkey_use_password, overwrite, suppress, save_coldkey_to_env, coldkey_password, py)?;
-        self.create_new_hotkey(12, hotkey_use_password, overwrite, suppress, save_hotkey_to_env, hotkey_password, py)?;
+        self.create_new_coldkey(
+            12,
+            coldkey_use_password,
+            overwrite,
+            suppress,
+            save_coldkey_to_env,
+            coldkey_password,
+            py,
+        )?;
+        self.create_new_hotkey(
+            12,
+            hotkey_use_password,
+            overwrite,
+            suppress,
+            save_hotkey_to_env,
+            hotkey_password,
+            py,
+        )?;
 
         Ok(self.clone())
     }
-
 
     /// Property that returns the hotkey file.
     #[getter]
@@ -294,7 +336,7 @@ except argparse.ArgumentError:
         Keyfile::new(
             hotkey_path.to_string_lossy().into_owned(),
             Some(self.hotkey.clone()),
-            save_hotkey_to_env
+            save_hotkey_to_env,
         )
     }
 
@@ -399,8 +441,13 @@ except argparse.ArgumentError:
         py: Python,
     ) -> PyResult<()> {
         self._coldkey = Some(keypair.clone());
-        self.create_coldkey_file(save_coldkey_to_env)?
-            .set_keypair(keypair, encrypt, overwrite, coldkey_password, py)
+        self.create_coldkey_file(save_coldkey_to_env)?.set_keypair(
+            keypair,
+            encrypt,
+            overwrite,
+            coldkey_password,
+            py,
+        )
     }
 
     /// Sets the coldkeypub for the wallet.
@@ -437,8 +484,13 @@ except argparse.ArgumentError:
         py: Python,
     ) -> PyResult<()> {
         self._hotkey = Some(keypair.clone());
-        self.create_hotkey_file(save_hotkey_to_env)?
-            .set_keypair(keypair.clone(), encrypt, overwrite, hotkey_password, py)
+        self.create_hotkey_file(save_hotkey_to_env)?.set_keypair(
+            keypair.clone(),
+            encrypt,
+            overwrite,
+            hotkey_password,
+            py,
+        )
     }
 
     /// Gets the coldkey from the wallet.
@@ -479,7 +531,14 @@ except argparse.ArgumentError:
             }
         }
 
-        self.set_coldkey(keypair.clone(), use_password, overwrite, save_coldkey_to_env, coldkey_password, py)?;
+        self.set_coldkey(
+            keypair.clone(),
+            use_password,
+            overwrite,
+            save_coldkey_to_env,
+            coldkey_password,
+            py,
+        )?;
         self.set_coldkeypub(keypair.clone(), false, overwrite, py)?;
         Ok(self.clone())
     }
@@ -504,7 +563,14 @@ except argparse.ArgumentError:
             }
         }
 
-        self.set_hotkey(keypair.clone(), use_password, overwrite, save_hotkey_to_env, hotkey_password, py)?;
+        self.set_hotkey(
+            keypair.clone(),
+            use_password,
+            overwrite,
+            save_hotkey_to_env,
+            hotkey_password,
+            py,
+        )?;
         Ok(self.clone())
     }
 
@@ -559,7 +625,15 @@ except argparse.ArgumentError:
         coldkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Wallet> {
-        self.create_new_coldkey(n_words, use_password, overwrite, suppress, save_coldkey_to_env, coldkey_password, py)
+        self.create_new_coldkey(
+            n_words,
+            use_password,
+            overwrite,
+            suppress,
+            save_coldkey_to_env,
+            coldkey_password,
+            py,
+        )
     }
 
     /// Creates a new coldkey, optionally encrypts it with the user-provided password and saves to disk.
@@ -588,7 +662,14 @@ except argparse.ArgumentError:
             use_password
         };
 
-        self.set_coldkey(keypair.clone(), use_password, overwrite, save_coldkey_to_env, coldkey_password, py)?;
+        self.set_coldkey(
+            keypair.clone(),
+            use_password,
+            overwrite,
+            save_coldkey_to_env,
+            coldkey_password,
+            py,
+        )?;
         self.set_coldkeypub(keypair.clone(), false, overwrite, py)?;
 
         Ok(self.clone())
@@ -606,7 +687,15 @@ except argparse.ArgumentError:
         hotkey_password: Option<String>,
         py: Python,
     ) -> PyResult<Wallet> {
-        self.create_new_hotkey(n_words, use_password, overwrite, suppress, save_hotkey_to_env, hotkey_password, py)
+        self.create_new_hotkey(
+            n_words,
+            use_password,
+            overwrite,
+            suppress,
+            save_hotkey_to_env,
+            hotkey_password,
+            py,
+        )
     }
 
     /// Creates a new hotkey, optionally encrypts it with the user-provided password and saves to disk.
@@ -635,7 +724,14 @@ except argparse.ArgumentError:
             use_password
         };
 
-        self.set_hotkey(keypair.clone(), use_password, overwrite, save_hotkey_to_env, hotkey_password, py)?;
+        self.set_hotkey(
+            keypair.clone(),
+            use_password,
+            overwrite,
+            save_hotkey_to_env,
+            hotkey_password,
+            py,
+        )?;
         Ok(self.clone())
     }
 
@@ -711,7 +807,14 @@ except argparse.ArgumentError:
             ));
         };
 
-        self.set_coldkey(keypair.clone(), use_password, overwrite, save_coldkey_to_env, coldkey_password, py)?;
+        self.set_coldkey(
+            keypair.clone(),
+            use_password,
+            overwrite,
+            save_coldkey_to_env,
+            coldkey_password,
+            py,
+        )?;
         self.set_coldkeypub(keypair.clone(), false, overwrite, py)?;
         Ok(self.clone())
     }
@@ -751,7 +854,14 @@ except argparse.ArgumentError:
             ));
         };
 
-        self.set_hotkey(keypair, use_password, overwrite, save_hotkey_to_env, hotkey_password, py)?;
+        self.set_hotkey(
+            keypair,
+            use_password,
+            overwrite,
+            save_hotkey_to_env,
+            hotkey_password,
+            py,
+        )?;
 
         Ok(self.clone())
     }

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -17,10 +17,12 @@
 
 import json
 import time
-import pytest
-from bittensor_wallet import Wallet, keyfile
-from ansible_vault import Vault
 from unittest.mock import patch
+
+import pytest
+from ansible_vault import Vault
+
+from bittensor_wallet import Wallet, keyfile
 
 
 def legacy_encrypt_keyfile_data(keyfile_data: bytes, password: str = None) -> bytes:


### PR DESCRIPTION
##  Brief :)
In terms of **manual** use, the current implementation has **not changed**.

### The implementation contains the following updates
1. All keys have a unique identifier for creating a variable in the local environment
- `wallet.coldkey_file.env_var_name`, `wallet.hotkey_file.env_var_name`;
2. The wallet's Keyfile get 2 new methods for saving and deleting an encrypted password to/from a local environment variable
- `wallet.coldkey_file.save_password_to_env(password: str)` **saves** passed password or asking type it.
- `wallet.hotkey_file.save_password_to_env(password: str)`
- `wallet.coldkey_file.remove_password_from_env()` **removes** associated password from local env variable.
- `wallet.hotkey_file.remove_password_from_env()`
3. **Only encrypted** passwords are saved in the local environment variable.
- Before saving the password, it is encrypted. After reading, it is decrypted inside the wallet.
4. All encryption/decryption methods use the password saved in the local environment variable.
- The process of checking for the presence of an encrypted password in an associative local environment variable applies to all key methods that encrypt and decrypt key data.

### Property `env_var_name`

All keys in the wallet have a property `env_var_name`. This value is unique within your operating system. Below is an example of how you can get this value.

**Example:**
If the key is located at
```
/Users/example/.bittensor/wallets/hotkeys/default
``` 
then name of the local environment variable will be
```
BT_PW__USERS_EXAMPLE__BITTENSOR_WALLETS_HOTKEYS_DEFAULT
```
**Example getting `env_var_name`:**

```python
from bittensor_wallet import Wallet

my_wallet = Wallet()
my_wallet.hotkey_file.env_var_name
Out[4]: 'BT_PW__USERS_ROMAN__BITTENSOR_WALLETS_DEFAULT_HOTKEYS_DEFAULT'
my_wallet.coldkey_file.env_var_name
Out[5]: 'BT_PW__USERS_ROMAN__BITTENSOR_WALLETS_DEFAULT_COLDKEY'
```

## Encryption/decryption usage
The saved password is used in the following cases:
1. Unlocking encrypted cold/hot keys
- `wallet.unlock_coldkey`, `wallet.unlock_hotkey` methods;
2. Creating a wallet
- `wallet.create` method;
6. recreating a wallet
- `wallet.recreate` method;
7. regenerating a hot/cold key
- `wallet.regenerate_coldkey`, `wallet.regenerate_hotkey` methods;
8. creating a keys separately
- `wallet.create_new_coldkey`,  wallet.create_new_hotkey methods;
9. encrypting and decrypting data for a specific key
- `wallet.coldkey_file.encrypt()`, `wallet.hotkey_file.encrypt()`, wallet.coldkey_file.decrypt(), `wallet.hotkey_file.decrypt()` methods.

### Arguments accepted by the `Wallet.create` method:
```python
"""
Checks for existing coldkeypub and hotkeys, and creates them if non-existent.

    Arguments:
        coldkey_use_password (bool): Whether to use a password for coldkey. Defaults to ``True``.
        hotkey_use_password (bool): Whether to use a password for hotkey. Defaults to ``False``.
        save_coldkey_to_env (bool): Whether to save a coldkey password to local env. Defaults to ``False``.
        save_hotkey_to_env (bool): Whether to save a hotkey password to local env. Defaults to ``False``.
        coldkey_password (Optional[str]): Coldkey password for encryption. Defaults to ``None``. If `coldkey_password` is passed, then `coldkey_use_password` is automatically ``True``.
        hotkey_password (Optional[str]): Hotkey password for encryption. Defaults to ``None``. If `hotkey_password` is passed, then `hotkey_use_password` is automatically ``True``.
        overwrite (bool): Whether to overwrite an existing keys. Defaults to ``False``.
        suppress (bool): If ``True``, suppresses the display of the keys mnemonic message. Defaults to ``False``.

    Returns:
        Wallet instance with created keys.
"""
```

**Example of creating a wallet and saving passwords to a local environment variable:**

```python
from bittensor_wallet import Wallet
from bittensor_wallet.keyfile import  keyfile_data_is_encrypted

w = Wallet(name="new_wallet", hotkey="myhotkey")
ck_pass = "c_testing"
hk_pass = "h_testing"

w.create(save_coldkey_to_env=True, save_hotkey_to_env=True, coldkey_password=ck_pass, hotkey_password=hk_pass, overwrite=True, suppress=True)

# coldkey file data is encrypted
print(">>> coldkey file data is encrypted", keyfile_data_is_encrypted(w.coldkey_file.data))
# hotkey file data is encrypted
print(">>> hotkey file data is encrypted", keyfile_data_is_encrypted(w.hotkey_file.data))

w.unlock_coldkey()
```

**Result of execution:**
```python
Encrypting...
The password has been saved to environment variable 'BT_PW__USERS_ROMAN__BITTENSOR_WALLETS_NEW_WALLET_COLDKEY'.
Encrypting...
The password has been saved to environment variable 'BT_PW__USERS_ROMAN__BITTENSOR_WALLETS_NEW_WALLET_HOTKEYS_MYHOTKEY'.
>>> coldkey file data is encrypted True
>>> hotkey file data is encrypted True

Decrypting...
<Keypair (address=5EF55E6DfkZec2CDxxxxxxxxxxxxxxxxxxxxxxxxxxh)>
```
