### PR TITLE
return encrypted password, remove debug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "termcolor",
     "eth-utils<2.3.0",
     "password_strength",
-    "cryptography~=42.0.5",
+    "cryptography~=43.0.1",
     "ansible~=6.7",
     "ansible_vault~=2.1",
     "munch~=2.5.0",

--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -498,10 +498,6 @@ fn encrypt_password(key: String, value: String) -> String {
         let encrypted_char = (c as u8) ^ (key.chars().nth(i % key.len()).unwrap() as u8);
         encrypted.push(encrypted_char as char);
     }
-    println!(
-        ">>> key: {}, value: {}, encrypted: {}",
-        key, value, encrypted
-    );
     encrypted
 }
 
@@ -1048,7 +1044,7 @@ impl Keyfile {
 
     /// Saves the key's password to the associated local environment variable.
     #[pyo3(signature = (password=None))]
-    fn save_password_to_env(&self, password: Option<String>, py: Python) -> PyResult<bool> {
+    fn save_password_to_env(&self, password: Option<String>, py: Python) -> PyResult<String> {
         // checking the password
         let password = match password {
             Some(pwd) => pwd,
@@ -1056,7 +1052,7 @@ impl Keyfile {
                 Ok(pwd) => pwd,
                 Err(e) => {
                     utils::print(format!("Error asking password: {:?}.\n", e));
-                    return Ok(false);
+                    return Ok("".parse()?);
                 }
             },
         };
@@ -1066,21 +1062,21 @@ impl Keyfile {
                 // encrypt password
                 let encrypted_password = encrypt_password(self.env_var_name()?, password);
                 // store encrypted password
-                env::set_var(&env_var_name, encrypted_password);
+                env::set_var(&env_var_name, &encrypted_password);
 
                 let message = format!(
                     "The password has been saved to environment variable '{}'.\n",
                     env_var_name
                 );
                 utils::print(message);
-                Ok(true)
+                Ok(encrypted_password)
             }
             Err(e) => {
                 utils::print(format!(
                     "Error saving environment variable name: {:?}.\n",
                     e
                 ));
-                Ok(false)
+                Ok("".parse()?)
             }
         }
     }


### PR DESCRIPTION
You can store your password with the following code:
```python
from bittensor_wallet import Wallet

my_wallet = Wallet()

# the same approach you can use `for hotkey_file` if this is encrypted.
boolean_result = my_wallet.coldkey_file.save_password_to_env("mypassword")
```

In `bittensor-wallet` version 2.0.2 method `save_password_to_env` returns `True` in successful case and `False` if something wrong. I gonna replace the return result to encrypted password. Then you can get it like this:
```python
from bittensor_wallet import Wallet

my_wallet = Wallet()

my_encrypted_password = my_wallet.coldkey_file.save_password_to_env("mypassword")
```