### PR TITLE
[fix] Use userhome for default wallet path ~

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
+ "shellexpand",
  "sodiumoxide",
  "sp-core",
 ]
@@ -2228,6 +2229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,7 +352,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bittensor_wallet"
-version = "2.0.0"
+version = "2.0.3"
 dependencies = [
  "ansible-vault",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bittensor_wallet"
-version = "2.0.0"
+version = "2.0.3"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ base64 = "0.22.1"
 scrypt = "0.11.0"
 pkcs8 = "0.10.2"
 schnorrkel = "0.11.4"
+shellexpand = "3.1.0"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bittensor-wallet"
-version = "2.0.2"
+version = "2.0.3"
 description = ""
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,3 @@
 pub const BT_WALLET_NAME: &str = "default";
 pub const BT_WALLET_HOTKEY: &str = "default";
-pub const BT_WALLET_PATH: &str = ".bittensor/wallets/";
+pub const BT_WALLET_PATH: &str = "~/.bittensor/wallets/";

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -4,6 +4,7 @@ use pyo3::types::{IntoPyDict, PyString, PyType};
 
 use colored::Colorize;
 use std::env;
+use std::path::PathBuf;
 
 use crate::config::Config;
 use crate::constants::{BT_WALLET_HOTKEY, BT_WALLET_NAME, BT_WALLET_PATH};
@@ -11,10 +12,6 @@ use crate::errors::KeyFileError;
 use crate::keyfile::Keyfile;
 use crate::keypair::Keypair;
 use crate::utils::{self, is_valid_bittensor_address_or_public_key};
-
-use dirs::home_dir;
-
-type PyRuntimeError = KeyFileError;
 
 /// Display the mnemonic and a warning message to keep the mnemonic safe.
 #[pyfunction]
@@ -34,7 +31,11 @@ pub fn display_mnemonic_msg(mnemonic: String, key_type: &str) {
 }
 
 // Function to safely retrieve attribute as Option<String> from passed python object
-fn get_attribute_string(py: Python, obj: &Bound<PyAny>, attr_name: &str) -> PyResult<Option<String>> {
+fn get_attribute_string(
+    py: Python,
+    obj: &Bound<PyAny>,
+    attr_name: &str,
+) -> PyResult<Option<String>> {
     match obj.getattr(attr_name) {
         Ok(attr) => {
             if attr.is_none() {
@@ -61,6 +62,8 @@ pub struct Wallet {
     pub path: String,
     pub hotkey: String,
 
+    _path: PathBuf,
+
     _coldkey: Option<Keypair>,
     _coldkeypub: Option<Keypair>,
     _hotkey: Option<Keypair>,
@@ -82,9 +85,8 @@ impl Wallet {
         hotkey: Option<String>,
         path: Option<String>,
         config: Option<PyObject>,
-        py: Python
+        py: Python,
     ) -> PyResult<Wallet> {
-
         // default config's values if config and config.wallet exist
         let mut conf_name: Option<String> = None;
         let mut conf_hotkey: Option<String> = None;
@@ -128,15 +130,19 @@ impl Wallet {
         let final_path = if let Some(path) = path {
             path
         } else if let Some(conf_path) = conf_path {
-            conf_path.strip_prefix("~/").unwrap_or(&conf_path).to_string()
+            conf_path
         } else {
             BT_WALLET_PATH.to_string()
         };
 
+        let expanded_path: PathBuf = PathBuf::from(shellexpand::tilde(&final_path).to_string());
+
         Ok(Wallet {
             name: final_name,
             hotkey: final_hotkey,
-            path: final_path,
+            path: final_path.clone(),
+
+            _path: expanded_path,
 
             _coldkey: None,
             _coldkeypub: None,
@@ -146,14 +152,14 @@ impl Wallet {
 
     fn __str__(&self) -> PyResult<String> {
         Ok(format!(
-            "Wallet (Name: '{:}', Hotkey: '{:}', Path: '~/{:}')",
+            "Wallet (Name: '{:}', Hotkey: '{:}', Path: '{:}')",
             self.name, self.hotkey, self.path
         ))
     }
 
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!(
-            "name: '{:}', hotkey: '{:}', path: '~/{:}'",
+            "name: '{:}', hotkey: '{:}', path: '{:}'",
             self.name, self.hotkey, self.path
         ))
     }
@@ -183,8 +189,8 @@ impl Wallet {
             env::var("BT_WALLET_NAME").unwrap_or_else(|_| BT_WALLET_NAME.to_string());
         let default_hotkey =
             env::var("BT_WALLET_HOTKEY").unwrap_or_else(|_| BT_WALLET_HOTKEY.to_string());
-        let default_path =
-            env::var("BT_WALLET_PATH").unwrap_or_else(|_| format!("~/{}", BT_WALLET_PATH.to_string()));
+        let default_path = env::var("BT_WALLET_PATH")
+            .unwrap_or_else(|_| format!("~/{}", BT_WALLET_PATH.to_string()));
 
         let prefix_str = if let Some(value) = prefix {
             format!("\"{}\"", value)
@@ -383,12 +389,8 @@ except argparse.ArgumentError:
     /// Created Hot Keyfile for Keypair
     #[pyo3(signature = (save_hotkey_to_env=false))]
     pub fn create_hotkey_file(&self, save_hotkey_to_env: bool) -> PyResult<Keyfile> {
-        // get home dir
-        let home = home_dir()
-            .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("Failed to get user home directory."))?;
-
         // concatenate wallet path
-        let wallet_path = home.join(&self.path).join(&self.name);
+        let wallet_path = self._path.join(&self.name);
 
         // concatenate hotkey path
         let hotkey_path = wallet_path.join("hotkeys").join(&self.hotkey);
@@ -409,12 +411,8 @@ except argparse.ArgumentError:
     /// Created Cold Keyfile for Keypair
     #[pyo3(signature = (save_coldkey_to_env=false))]
     pub fn create_coldkey_file(&self, save_coldkey_to_env: bool) -> PyResult<Keyfile> {
-        // get home dir
-        let home = home_dir()
-            .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("Failed to get user home directory."))?;
-
         // concatenate wallet path
-        let wallet_path = home.join(&self.path).join(&self.name);
+        let wallet_path = PathBuf::from(&self._path).join(&self.name);
 
         // concatenate coldkey path
         let coldkey_path = wallet_path.join("coldkey");
@@ -428,12 +426,8 @@ except argparse.ArgumentError:
     /// Property that returns the coldkeypub file.
     #[getter]
     pub fn coldkeypub_file(&self) -> PyResult<Keyfile> {
-        // get home dir
-        let home = home_dir()
-            .ok_or_else(|| PyErr::new::<PyRuntimeError, _>("Failed to get user home directory."))?;
-
         // concatenate wallet path
-        let wallet_path = home.join(&self.path).join(&self.name);
+        let wallet_path = self._path.join(&self.name);
 
         // concatenate hotkey path
         let coldkeypub_path = wallet_path.join("coldkeypub.txt");


### PR DESCRIPTION
Changes the constant wallet path to use `~/` prefix on the path, making default wallet paths valid in `btcli` 