### PR TITLE
fix: Prevent infinite loop when password is not strong enough

### DIFF
--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -186,12 +186,15 @@ pub fn validate_password(_py: Python, password: &str) -> PyResult<bool> {
 #[pyfunction]
 pub fn ask_password(py: Python, validation_required: bool) -> PyResult<String> {
     let mut valid = false;
-    let password = utils::prompt_password("Enter your password: ".to_string());
-
+    let mut password = utils::prompt_password("Enter your password: ".to_string());
+    
     if validation_required {
         while !valid {
-            if let Some(ref password) = password {
-                valid = validate_password(py, &password)?;
+            if let Some(ref pwd) = password {
+                valid = validate_password(py, &pwd)?;
+                if !valid {
+                    password = utils::prompt_password("Enter your password again: ".to_string());
+                }
             } else {
                 valid = true
             }


### PR DESCRIPTION
```
IMPORTANT: Store this mnemonic in a secure (preferable offline place), as anyone who has possession of this mnemonic can use it to regenerate the key and access your tokens.

The mnemonic to the new coldkey is: ...
You can use the mnemonic to recreate the key with `btcli` in case it gets lost.
Enter your password: q
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
Password not strong enough. Try increasing the length of the password or the password complexity.
...
```