### PR TITLE
Removes ansible from requirements. But the second requirements.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "eth-utils<2.3.0",
     "password_strength",
     "cryptography~=43.0.1",
-    "ansible~=6.7",
     "ansible_vault~=2.1",
     "munch~=2.5.0",
     "rich",


### PR DESCRIPTION
Builds upon #68. Apparently this has two lists of Python requirements. This removes it from the second list.