### PR TITLE
Fix `KeyPair.regenerate_*` methods using `seed`

### DIFF
--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -327,8 +327,11 @@ impl PyKeypair {
     }
 
     #[getter]
-    fn seed_hex(&self) -> Option<Vec<u8>> {
-        self.inner.seed_hex()
+    fn seed_hex(&self, py: Python) -> PyResult<PyObject> {
+        match self.inner.seed_hex() {
+            Some(seed) => Ok(PyBytes::new_bound(py, &seed).into_py(py)),
+            None => Ok(py.None()),
+        }
     }
 
     #[getter]
@@ -1197,10 +1200,10 @@ except argparse.ArgumentError:
         mnemonic=None,
         seed=None,
         json=None,
-        use_password=None,
-        overwrite=None,
-        suppress=None,
-        save_coldkey_to_env=None,
+        use_password=true,
+        overwrite=false,
+        suppress=false,
+        save_coldkey_to_env=false,
         coldkey_password=None
     ))]
     fn regenerate_coldkey(
@@ -1220,7 +1223,7 @@ except argparse.ArgumentError:
                 mnemonic,
                 seed,
                 json,
-                use_password.unwrap_or(false),
+                use_password.unwrap_or(true),
                 overwrite.unwrap_or(false),
                 suppress.unwrap_or(false),
                 save_coldkey_to_env.unwrap_or(false),
@@ -1255,10 +1258,10 @@ except argparse.ArgumentError:
         mnemonic=None,
         seed=None,
         json=None,
-        use_password=None,
-        overwrite=None,
-        suppress=None,
-        save_hotkey_to_env=None,
+        use_password=true,
+        overwrite=false,
+        suppress=false,
+        save_hotkey_to_env=false,
         hotkey_password=None
     ))]
     fn regenerate_hotkey(

--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -1245,7 +1245,7 @@ except argparse.ArgumentError:
         mnemonic=None,
         seed=None,
         json=None,
-        use_password=true,
+        use_password=false,
         overwrite=false,
         suppress=false,
         save_hotkey_to_env=false,

--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -327,14 +327,6 @@ impl PyKeypair {
     }
 
     #[getter]
-    fn seed_hex(&self, py: Python) -> PyResult<PyObject> {
-        match self.inner.seed_hex() {
-            Some(seed) => Ok(PyBytes::new_bound(py, &seed).into_py(py)),
-            None => Ok(py.None()),
-        }
-    }
-
-    #[getter]
     fn crypto_type(&self) -> u8 {
         self.inner.crypto_type()
     }
@@ -342,11 +334,6 @@ impl PyKeypair {
     #[setter]
     fn set_crypto_type(&mut self, crypto_type: u8) {
         self.inner.set_crypto_type(crypto_type)
-    }
-
-    #[getter]
-    fn mnemonic(&self) -> Option<String> {
-        self.inner.mnemonic()
     }
 }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -719,7 +719,7 @@ impl Wallet {
             keypair
         } else if let Some(seed) = seed {
             // seed
-            Keypair::create_from_seed(seed.as_bytes().to_vec())
+            Keypair::create_from_seed(hex::decode(seed).unwrap())
                 .map_err(|e| KeyFileError::Generic(e.to_string()))?
         } else if let Some((json_data, passphrase)) = json {
             // json_data + passphrase
@@ -764,7 +764,7 @@ impl Wallet {
             keypair
         } else if let Some(seed) = seed {
             // seed
-            Keypair::create_from_seed(seed.as_bytes().to_vec())
+            Keypair::create_from_seed(hex::decode(seed).unwrap())
                 .map_err(|e| KeyFileError::Generic(e.to_string()))?
         } else if let Some((json_data, passphrase)) = json {
             // json_data + passphrase

--- a/tests/test_keyfile.py
+++ b/tests/test_keyfile.py
@@ -423,7 +423,6 @@ def test_serialized_keypair_to_keyfile_data(keyfile_setup_teardown):
     keypair_data = serialized_keypair_to_keyfile_data(keypair)
     decoded_keypair_data = json.loads(keypair_data.decode())
 
-    assert decoded_keypair_data["secretPhrase"] == keypair.mnemonic
     assert decoded_keypair_data["ss58Address"] == keypair.ss58_address
     assert decoded_keypair_data["publicKey"] == f"0x{keypair.public_key.hex()}"
     assert decoded_keypair_data["accountId"] == f"0x{keypair.public_key.hex()}"

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -514,9 +514,7 @@ def test_unlock_hotkey(mock_wallet):
     assert result.ss58_address == mock_wallet.get_hotkey().ss58_address
     assert result.public_key == mock_wallet.get_hotkey().public_key
     assert result.ss58_format == mock_wallet.get_hotkey().ss58_format
-    assert result.seed_hex == mock_wallet.get_hotkey().seed_hex
     assert result.crypto_type == mock_wallet.get_hotkey().crypto_type
-    assert result.mnemonic == mock_wallet.get_hotkey().mnemonic
 
 
 def test_unlock_coldkey(mock_wallet):
@@ -528,9 +526,7 @@ def test_unlock_coldkey(mock_wallet):
     assert result.ss58_address == mock_wallet.get_coldkey().ss58_address
     assert result.public_key == mock_wallet.get_coldkey().public_key
     assert result.ss58_format == mock_wallet.get_coldkey().ss58_format
-    assert result.seed_hex == mock_wallet.get_coldkey().seed_hex
     assert result.crypto_type == mock_wallet.get_coldkey().crypto_type
-    assert result.mnemonic == mock_wallet.get_coldkey().mnemonic
 
 
 def test_unlock_coldkeypub(mock_wallet):
@@ -541,9 +537,7 @@ def test_unlock_coldkeypub(mock_wallet):
     assert result.ss58_address == mock_wallet.get_coldkeypub().ss58_address
     assert result.public_key == mock_wallet.get_coldkeypub().public_key
     assert result.ss58_format == mock_wallet.get_coldkeypub().ss58_format
-    assert result.seed_hex == mock_wallet.get_coldkeypub().seed_hex
     assert result.crypto_type == mock_wallet.get_coldkeypub().crypto_type
-    assert result.mnemonic == mock_wallet.get_coldkeypub().mnemonic
 
 
 def test_wallet_string_representation_with_default_arguments():


### PR DESCRIPTION
- fixed `KeyPair.regenerate_*` methods
- remove KeyPair fields with sensitive data (`seed_hex`, `private_key`, and `mnemonic`)