### PR TITLE
Fix `pyo3_runtime.PanicException` when encrypted password has `NUL byte`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,6 +34,10 @@ pub enum KeyFileError {
     EnvVarError(String),
     #[error("Password error: {0}")]
     PasswordError(String),
+    #[error("Base64 decoding error: {0}")]
+    Base64DecodeError(String),
+    #[error("Base64 encoding error: {0}")]
+    Base64EncodeError(String),
     #[error("Generic error: {0}")]
     Generic(String),
 }

--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -118,6 +118,12 @@ impl PyKeyfile {
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }
 
+    fn env_var_name(&self) -> PyResult<String> {
+        self.inner
+            .env_var_name()
+            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
+    }
+
     #[pyo3(signature = (password=None))]
     fn save_password_to_env(&self, password: Option<String>) -> PyResult<String> {
         self.inner
@@ -827,6 +833,54 @@ except argparse.ArgumentError:
         let result = self
             .inner
             .create_if_non_existent(
+                coldkey_use_password.unwrap_or(true),
+                hotkey_use_password.unwrap_or(false),
+                save_coldkey_to_env.unwrap_or(false),
+                save_hotkey_to_env.unwrap_or(false),
+                coldkey_password,
+                hotkey_password,
+                overwrite.unwrap_or(false),
+                suppress.unwrap_or(false),
+            )
+            .map_err(|e| match e {
+                WalletError::InvalidInput(_) | WalletError::KeyGeneration(_) => {
+                    PyErr::new::<PyValueError, _>(e.to_string())
+                }
+                _ => PyErr::new::<PyKeyFileError, _>(format!("Failed to create wallet: {:?}", e)),
+            })?;
+
+        Ok(Wallet { inner: result })
+    }
+
+    /// Checks for existing coldkeypub and hotkeys, and creates them if non-existent.
+    ///     Arguments:
+    ///         coldkey_use_password (bool): Whether to use a password for coldkey. Defaults to ``True``.
+    ///         hotkey_use_password (bool): Whether to use a password for hotkey. Defaults to ``False``.
+    ///         save_coldkey_to_env (bool): Whether to save a coldkey password to local env. Defaults to ``False``.
+    ///         save_hotkey_to_env (bool): Whether to save a hotkey password to local env. Defaults to ``False``.
+    ///         coldkey_password (Optional[str]): Coldkey password for encryption. Defaults to ``None``. If `coldkey_password` is passed, then `coldkey_use_password` is automatically ``True``.
+    ///         hotkey_password (Optional[str]): Hotkey password for encryption. Defaults to ``None``. If `hotkey_password` is passed, then `hotkey_use_password` is automatically ``True``.
+    ///         overwrite (bool): Whether to overwrite an existing keys. Defaults to ``False``.
+    ///         suppress (bool): If ``True``, suppresses the display of the keys mnemonic message. Defaults to ``False``.
+    ///
+    ///     Returns:
+    ///         Wallet instance with created keys.
+
+    #[pyo3(signature = (coldkey_use_password=true, hotkey_use_password=false, save_coldkey_to_env=false, save_hotkey_to_env=false, coldkey_password=None, hotkey_password=None, overwrite=false, suppress=false))]
+    pub fn create(
+        &mut self,
+        coldkey_use_password: Option<bool>,
+        hotkey_use_password: Option<bool>,
+        save_coldkey_to_env: Option<bool>,
+        save_hotkey_to_env: Option<bool>,
+        coldkey_password: Option<String>,
+        hotkey_password: Option<String>,
+        overwrite: Option<bool>,
+        suppress: Option<bool>,
+    ) -> PyResult<Self> {
+        let result = self
+            .inner
+            .create(
                 coldkey_use_password.unwrap_or(true),
                 hotkey_use_password.unwrap_or(false),
                 save_coldkey_to_env.unwrap_or(false),

--- a/tests/test_keyfile.py
+++ b/tests/test_keyfile.py
@@ -28,6 +28,7 @@ from bittensor_wallet.errors import ConfigurationError, KeyFileError
 from bittensor_wallet.keyfile import Keyfile
 from bittensor_wallet.keyfile import get_coldkey_password_from_environment
 from bittensor_wallet.keypair import Keypair
+from bittensor_wallet import Wallet
 
 
 def test_generate_mnemonic():
@@ -62,8 +63,8 @@ def test_only_provide_ss58_address():
     keypair = Keypair(ss58_address="16ADqpMa4yzfmWs3nuTSMhfZ2ckeGtvqhPWCNqECEGDcGgU2")
 
     assert (
-        f"0x{keypair.public_key.hex()}"
-        == "0xe4359ad3e2716c539a1d663ebd0a51bdc5c98a12e663bb4c4402db47828c9446"
+            f"0x{keypair.public_key.hex()}"
+            == "0xe4359ad3e2716c539a1d663ebd0a51bdc5c98a12e663bb4c4402db47828c9446"
     )
 
 
@@ -197,8 +198,8 @@ def test_create_keypair_from_private_key():
         private_key="0x1f1995bdf3a17b60626a26cfe6f564b337d46056b7a1281b64c649d592ccda0a9cffd34d9fb01cae1fba61aeed184c817442a2186d5172416729a4b54dd4b84e",
     )
     assert (
-        f"0x{keypair.public_key.hex()}"
-        == "0xe4359ad3e2716c539a1d663ebd0a51bdc5c98a12e663bb4c4402db47828c9446"
+            f"0x{keypair.public_key.hex()}"
+            == "0xe4359ad3e2716c539a1d663ebd0a51bdc5c98a12e663bb4c4402db47828c9446"
     )
 
 
@@ -326,12 +327,12 @@ def test_create(keyfile_setup_teardown):
     str(keyfile)
 
     assert (
-        keyfile.get_keypair(password="thisisafakepassword").ss58_address
-        == alice.ss58_address
+            keyfile.get_keypair(password="thisisafakepassword").ss58_address
+            == alice.ss58_address
     )
     assert (
-        keyfile.get_keypair(password="thisisafakepassword").public_key
-        == alice.public_key
+            keyfile.get_keypair(password="thisisafakepassword").public_key
+            == alice.public_key
     )
 
     bob = Keypair.create_from_uri("/Bob")
@@ -339,11 +340,11 @@ def test_create(keyfile_setup_teardown):
         bob, encrypt=True, overwrite=True, password="thisisafakepassword"
     )
     assert (
-        keyfile.get_keypair(password="thisisafakepassword").ss58_address
-        == bob.ss58_address
+            keyfile.get_keypair(password="thisisafakepassword").ss58_address
+            == bob.ss58_address
     )
     assert (
-        keyfile.get_keypair(password="thisisafakepassword").public_key == bob.public_key
+            keyfile.get_keypair(password="thisisafakepassword").public_key == bob.public_key
     )
 
     repr(keyfile)
@@ -457,18 +458,39 @@ def test_deserialize_keypair_from_keyfile_data(keyfile_setup_teardown):
 
 
 @pytest.mark.parametrize(
-    "env_name,encrypted,decrypted",
+    "encrypted,decrypted",
     [
-        ("BT_PW_COLD_WALLET", "61,$>18", "testin{"),
-        ("BT_PW_COLD_WALLET", " =+$21,:!t``", "bittenoum0?7"),
+        ("c2ZsZGJpaG1q", "123456789"),
+        ("ID0rJDIxLDoh", "bittensor"),
+        ("NjEsJD4xOA==", "testing"),
     ],
 )
 def test_get_coldkey_password_from_environment(
-    monkeypatch, env_name, encrypted, decrypted
+        tmp_path, encrypted, decrypted
 ):
     # Preps
-    monkeypatch.setenv(env_name, encrypted)
+    assert tmp_path.exists()
+    assert tmp_path.is_dir()
+
+    wallet_name = "test_wallet"
+    tmp_path_str = str(tmp_path)
+
+    # env_name = f"BT_PW_{tmp_path_str.replace(".", "_").replace(os.path.sep, "_")}_{wallet_name}_COLDKEY".upper()
+
+    wallet = Wallet(name=wallet_name, path=str(tmp_path))
+    wallet.create(
+        coldkey_use_password=True,
+        hotkey_use_password=False,
+        save_coldkey_to_env=True,
+        save_hotkey_to_env=False,
+        coldkey_password=decrypted,
+        overwrite=True,
+        suppress=True
+    )
+
+    # Call
+    wallet.coldkey_file.save_password_to_env(decrypted)
 
     # Calls + Assertions
-    assert get_coldkey_password_from_environment(env_name) == decrypted
+    assert get_coldkey_password_from_environment(wallet.coldkey_file.env_var_name()) == decrypted
     assert get_coldkey_password_from_environment("non_existent_env_variable") is None

--- a/tests/test_keyfile.py
+++ b/tests/test_keyfile.py
@@ -473,9 +473,6 @@ def test_get_coldkey_password_from_environment(
     assert tmp_path.is_dir()
 
     wallet_name = "test_wallet"
-    tmp_path_str = str(tmp_path)
-
-    # env_name = f"BT_PW_{tmp_path_str.replace(".", "_").replace(os.path.sep, "_")}_{wallet_name}_COLDKEY".upper()
 
     wallet = Wallet(name=wallet_name, path=str(tmp_path))
     wallet.create(


### PR DESCRIPTION
### Improved logic for:
- `Keyfile.encrypt_password`
- `Keyfile.decrypt_password`

### Added back python methods:
- `Keyfile.env_var_name`
- `Wallet.create`

### Testing:
1. create wallet with coldkey password `900P12qw`
2. run the next code snippet:
```python
from bittensor import Wallet

wallet = Wallet(name="wallet_name")

password = "900P12qw"
wallet.coldkey_file.save_password_to_env(password)
print(wallet.coldkey.ss58_address)
```