### PR TITLE
Release/3.0.4

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.0.4 /2025-02-19
+
+## What's Changed
+* Fix `pyo3_runtime.PanicException` when encrypted password has `NUL byte` by @roman-opentensor in https://github.com/opentensor/btwallet/pull/99
+* Backmerge main to staging 303 by @ibraheem-opentensor in https://github.com/opentensor/btwallet/pull/102
+
+**Full Changelog**: https://github.com/opentensor/btwallet/compare/v3.0.3...v3.0.4
+
 ## 3.0.3 /2025-02-13
 
 ## What's Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bittensor_wallet"
-version = "3.0.3"
+version = "3.0.4"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bittensor-wallet"
-version = "3.0.3"
+version = "3.0.4"
 description = ""
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## 3.0.4 /2025-02-19

## What's Changed
* Fix `pyo3_runtime.PanicException` when encrypted password has `NUL byte` by @roman-opentensor in https://github.com/opentensor/btwallet/pull/99
* Backmerge main to staging 303 by @ibraheem-opentensor in https://github.com/opentensor/btwallet/pull/102

**Full Changelog**: https://github.com/opentensor/btwallet/compare/v3.0.3...v3.0.4