### PR TITLE
chore(pyo3): use CARGO_PKG_VERSION to auto-sync Python binding version with crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bittensor_wallet"
-version = "3.0.8"
+version = "3.0.10"
 edition = "2021"
 
 [lib]

--- a/bittensor_wallet/__init__.py
+++ b/bittensor_wallet/__init__.py
@@ -11,6 +11,7 @@ from bittensor_wallet.bittensor_wallet import (
     keypair,
     utils,
     wallet,
+    __version__
 )
 
 # classes
@@ -26,6 +27,3 @@ keyfile = keyfile
 keypair = keypair
 utils = utils
 wallet = wallet
-
-# bump version in `pyproject.toml` only
-__version__ = importlib.metadata.version("bittensor-wallet")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,40 +1,37 @@
 [project]
 name = "bittensor-wallet"
-version = "3.0.10"
+dynamic = ["version"]
 description = ""
 readme = "README.md"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 keywords = ["substrate", "scale", "codec", "bittensor", "wallet"]
 
 dependencies = [
-    "password_strength",
-    "cryptography~=43.0.1",
-    "py-bip39-bindings==0.1.11",
+  "password_strength",
+  "cryptography~=43.0.1",
+  "py-bip39-bindings==0.1.11",
 ]
 requires-python = ">= 3.9"
 
-authors = [
-  {name = "Roman Chkhaidze", email = "roman@opentensor.dev"},
-]
-maintainers = [
-  {name = "Cortex Team", email = "cortex@opentensor.dev"},
-]
+authors = [{ name = "Roman Chkhaidze", email = "roman@opentensor.dev" }]
+maintainers = [{ name = "Cortex Team", email = "cortex@opentensor.dev" }]
 classifiers = [
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Topic :: Software Development :: Build Tools",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Scientific/Engineering :: Mathematics",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "Topic :: Software Development",
-        "Topic :: Software Development :: Libraries",
-        "Topic :: Software Development :: Libraries :: Python Modules",]
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Build Tools",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Scientific/Engineering :: Mathematics",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
 
 [project.urls]
 Repository = "https://github.com/opentensor/btwallet"
@@ -49,28 +46,28 @@ exclude = ["tests*"]
 
 [project.optional-dependencies]
 dev = [
-    "pytest==7.2.0",
-    "pytest-asyncio==0.23.7",
-    "pytest-mock==3.12.0",
-    "pytest-split==0.8.0",
-    "pytest-xdist==3.0.2",
-    "pytest-rerunfailures==10.2",
-    "coveralls==3.3.1",
-    "pytest-cov==4.0.0",
-    "ddt==1.6.0",
-    "hypothesis==6.81.1",
-    "flake8==7.0.0",
-    "mypy==1.8.0",
-    "types-retry==0.9.9.4",
-    "freezegun==1.5.0",
-    "httpx==0.27.0",
-    "ruff==0.4.7",
-    "aioresponses==0.7.6",
-    "factory-boy==3.3.0",
-    "maturin==1.8.3",
-    "py-bip39-bindings==0.1.11",
-    "ansible_vault~=2.1",
-    "bittensor>=9.0.1",
-    "substrate-interface==1.7.11",
-    "scalecodec~=1.2.11",
+  "pytest==7.2.0",
+  "pytest-asyncio==0.23.7",
+  "pytest-mock==3.12.0",
+  "pytest-split==0.8.0",
+  "pytest-xdist==3.0.2",
+  "pytest-rerunfailures==10.2",
+  "coveralls==3.3.1",
+  "pytest-cov==4.0.0",
+  "ddt==1.6.0",
+  "hypothesis==6.81.1",
+  "flake8==7.0.0",
+  "mypy==1.8.0",
+  "types-retry==0.9.9.4",
+  "freezegun==1.5.0",
+  "httpx==0.27.0",
+  "ruff==0.4.7",
+  "aioresponses==0.7.6",
+  "factory-boy==3.3.0",
+  "maturin==1.8.3",
+  "py-bip39-bindings==0.1.11",
+  "ansible_vault~=2.1",
+  "bittensor>=9.0.1",
+  "substrate-interface==1.7.11",
+  "scalecodec~=1.2.11",
 ]

--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -485,6 +485,9 @@ fn bittensor_wallet(module: Bound<'_, PyModule>) -> PyResult<()> {
     register_keypair_module(module.clone())?;
     register_utils_module(module.clone())?;
     register_wallet_module(module)?;
+
+    // Add cargo package verions
+    module.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }
 

--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -478,27 +478,28 @@ fn bittensor_wallet(module: Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyKeypair>()?;
     module.add_class::<Wallet>()?;
 
-    // Add submodules to the main module
-    register_config_module(module.clone())?;
-    register_errors_module(module.clone())?;
-    register_keyfile_module(module.clone())?;
-    register_keypair_module(module.clone())?;
-    register_utils_module(module.clone())?;
-    register_wallet_module(module)?;
-
     // Add cargo package verions
     module.add("__version__", env!("CARGO_PKG_VERSION"))?;
+
+    // Add submodules to the main module
+    register_config_module(&module)?;
+    register_errors_module(&module)?;
+    register_keyfile_module(&module)?;
+    register_keypair_module(&module)?;
+    register_utils_module(&module)?;
+    register_wallet_module(&module)?;
+
     Ok(())
 }
 
 // Define the submodule registration functions
-fn register_config_module(main_module: Bound<'_, PyModule>) -> PyResult<()> {
+fn register_config_module(main_module: &Bound<'_, PyModule>) -> PyResult<()> {
     let config_module = PyModule::new_bound(main_module.py(), "config")?;
     config_module.add_class::<Config>()?;
     main_module.add_submodule(&config_module)
 }
 
-fn register_errors_module(main_module: Bound<'_, PyModule>) -> PyResult<()> {
+fn register_errors_module(main_module: &Bound<'_, PyModule>) -> PyResult<()> {
     let errors_module = PyModule::new_bound(main_module.py(), "errors")?;
     // Register the WalletError exception
     errors_module.add_class::<PyWalletError>()?;
@@ -570,7 +571,7 @@ fn py_decrypt_keyfile_data(
 }
 
 // keyfile module with functions
-fn register_keyfile_module(main_module: Bound<'_, PyModule>) -> PyResult<()> {
+fn register_keyfile_module(main_module: &Bound<'_, PyModule>) -> PyResult<()> {
     let keyfile_module = PyModule::new_bound(main_module.py(), "keyfile")?;
     keyfile_module.add_function(wrap_pyfunction!(
         py_serialized_keypair_to_keyfile_data,
@@ -616,7 +617,7 @@ fn register_keyfile_module(main_module: Bound<'_, PyModule>) -> PyResult<()> {
     main_module.add_submodule(&keyfile_module)
 }
 
-fn register_keypair_module(main_module: Bound<'_, PyModule>) -> PyResult<()> {
+fn register_keypair_module(main_module: &Bound<'_, PyModule>) -> PyResult<()> {
     let keypair_module = PyModule::new_bound(main_module.py(), "keypair")?;
     keypair_module.add_class::<PyKeypair>()?;
     main_module.add_submodule(&keypair_module)
@@ -668,7 +669,7 @@ fn py_is_valid_bittensor_address_or_public_key(address: &Bound<'_, PyAny>) -> bo
     })
 }
 
-fn register_utils_module(main_module: Bound<'_, PyModule>) -> PyResult<()> {
+fn register_utils_module(main_module: &Bound<'_, PyModule>) -> PyResult<()> {
     let utils_module = PyModule::new_bound(main_module.py(), "utils")?;
     utils_module.add_function(wrap_pyfunction!(
         crate::utils::is_valid_ss58_address,
@@ -689,7 +690,7 @@ fn register_utils_module(main_module: Bound<'_, PyModule>) -> PyResult<()> {
     main_module.add_submodule(&utils_module)
 }
 
-fn register_wallet_module(main_module: Bound<'_, PyModule>) -> PyResult<()> {
+fn register_wallet_module(main_module: &Bound<'_, PyModule>) -> PyResult<()> {
     let wallet_module = PyModule::new_bound(main_module.py(), "wallet")?;
     wallet_module.add_function(wrap_pyfunction!(
         crate::wallet::display_mnemonic_msg,


### PR DESCRIPTION
## Summary
use env variable `CARGO_PKG_VERSION` to your advantage to maintain, and better version py03 binding. Also fixed useless cloning of the Bound<'_, PyModule>, by just handling reference.

## The Gist of added Features

```rust
 module.add("__version__", env!("CARGO_PKG_VERSION"))?;
```

### Old 
```
main_module: Bound<'_, PyModule>
```

### New
```
main_module: &Bound<'_, PyModule>
```