### PR TITLE
Support Windows & Fix warnings

### DIFF
--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -142,7 +142,7 @@ impl PyKeyfile {
     }
 
     #[getter(data)]
-    fn data_py(&self) -> PyResult<Option<Cow<[u8]>>> {
+    fn data_py(&self) -> PyResult<Option<Cow<'_, [u8]>>> {
         self.inner
             .data()
             .map(|vec| Some(Cow::Owned(vec)))
@@ -266,7 +266,7 @@ impl PyKeypair {
     }
 
     #[pyo3(signature = (data))]
-    fn sign(&self, data: Py<PyAny>, py: Python) -> PyResult<Cow<[u8]>> {
+    fn sign(&self, data: Py<PyAny>, py: Python) -> PyResult<Cow<'_, [u8]>> {
         // Convert data to bytes (data can be a string, hex, or bytes)
         let data_bound = data.bind(py);
         let data_bytes = if let Ok(s) = data_bound.extract::<String>() {
@@ -348,7 +348,7 @@ impl PyKeypair {
     }
 
     #[getter]
-    fn public_key(&self) -> PyResult<Option<Cow<[u8]>>> {
+    fn public_key(&self) -> PyResult<Option<Cow<'_, [u8]>>> {
         self.inner
             .public_key()
             .map(|opt| opt.map(Cow::from))
@@ -555,7 +555,10 @@ fn py_get_password_from_environment(env_var_name: String) -> PyResult<Option<Str
 
 #[pyfunction(name = "encrypt_keyfile_data")]
 #[pyo3(signature = (keyfile_data, password=None))]
-fn py_encrypt_keyfile_data(keyfile_data: &[u8], password: Option<String>) -> PyResult<Cow<[u8]>> {
+fn py_encrypt_keyfile_data(
+    keyfile_data: &[u8],
+    password: Option<String>,
+) -> PyResult<Cow<'_, [u8]>> {
     keyfile::encrypt_keyfile_data(keyfile_data, password)
         .map(Cow::from)
         .map_err(|e| PyErr::new::<PyKeyFileError, _>(e))
@@ -567,7 +570,7 @@ fn py_decrypt_keyfile_data(
     keyfile_data: &[u8],
     password: Option<String>,
     password_env_var: Option<String>,
-) -> PyResult<Cow<[u8]>> {
+) -> PyResult<Cow<'_, [u8]>> {
     keyfile::decrypt_keyfile_data(keyfile_data, password, password_env_var)
         .map(Cow::from)
         .map_err(|e| PyErr::new::<PyKeyFileError, _>(e))


### PR DESCRIPTION
# Summary
- **Fixes Windows build** by gating Unix-specific permission APIs and cleaning up platform warnings. 
- **Clarifies PyO3 lifetime annotations** to silence mismatched lifetime warnings.

# Changes
- **Added** conditional compilation for Unix-only PermissionsExt usage and permission checks, with Windows-safe fallbacks.
- **Removed** unused Windows metadata variables behind cfg to avoid unused warnings.
- **Normalized** PyO3 return signatures to use explicit '_ lifetimes for Cow<[u8]> in bindings, resolving lifetime syntax warnings.
# Testing
`cargo build --release on Windows (msvc)`
`maturin develop --release after installing maturin`