### PR TITLE
Make `pyo3` optional for crate usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,6 @@ optional = true
 features = ["vendored"]
 
 [features]
-extension-module = ["pyo3", "pyo3/extension-module"]
+python-bindings = ["dep:pyo3", "pyo3/extension-module"]
 vendored-openssl = ["openssl-sys/vendored"]
-default = ["extension-module"]
+default = ["python-bindings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 sp-core = "34.0.0"
-pyo3 = { version = "0.26.0", features = ["generate-import-lib"] }
+pyo3 = { version = "0.26.0", features = ["generate-import-lib"], optional = true }
 bip39 = { version = "2.0.0", features = ["rand"] }
 hex = "0.4.3"
 colored = "2.1.0"
@@ -37,7 +37,6 @@ optional = true
 features = ["vendored"]
 
 [features]
-extension-module = ["pyo3/extension-module"]
+extension-module = ["pyo3", "pyo3/extension-module"]
 vendored-openssl = ["openssl-sys/vendored"]
 default = ["extension-module"]
-python-bindings = []

--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -12,7 +12,6 @@ use fernet::Fernet;
 use base64::{engine::general_purpose, Engine as _};
 use passwords::analyzer;
 use passwords::scorer;
-use pyo3::pyfunction;
 use serde_json::json;
 
 use crate::errors::KeyFileError;
@@ -164,25 +163,25 @@ pub fn ask_password(validation_required: bool) -> Result<String, KeyFileError> {
 }
 
 /// Returns `true` if the keyfile data is NaCl encrypted.
-#[pyfunction]
+#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
 pub fn keyfile_data_is_encrypted_nacl(keyfile_data: &[u8]) -> bool {
     keyfile_data.starts_with(b"$NACL")
 }
 
 /// Returns true if the keyfile data is ansible encrypted.
-#[pyfunction]
+#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
 pub fn keyfile_data_is_encrypted_ansible(keyfile_data: &[u8]) -> bool {
     keyfile_data.starts_with(b"$ANSIBLE_VAULT")
 }
 
 /// Returns true if the keyfile data is legacy encrypted.
-#[pyfunction]
+#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
 pub fn keyfile_data_is_encrypted_legacy(keyfile_data: &[u8]) -> bool {
     keyfile_data.starts_with(b"gAAAAA")
 }
 
 /// Returns `true` if the keyfile data is encrypted.
-#[pyfunction]
+#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
 pub fn keyfile_data_is_encrypted(keyfile_data: &[u8]) -> bool {
     let nacl = keyfile_data_is_encrypted_nacl(keyfile_data);
     let ansible = keyfile_data_is_encrypted_ansible(keyfile_data);
@@ -191,7 +190,7 @@ pub fn keyfile_data_is_encrypted(keyfile_data: &[u8]) -> bool {
 }
 
 /// Returns type of encryption method as a string.
-#[pyfunction]
+#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
 pub fn keyfile_data_encryption_method(keyfile_data: &[u8]) -> String {
     if keyfile_data_is_encrypted_nacl(keyfile_data) {
         "NaCl"

--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -163,25 +163,25 @@ pub fn ask_password(validation_required: bool) -> Result<String, KeyFileError> {
 }
 
 /// Returns `true` if the keyfile data is NaCl encrypted.
-#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
+#[cfg_attr(feature = "python-bindings", pyo3::pyfunction)]
 pub fn keyfile_data_is_encrypted_nacl(keyfile_data: &[u8]) -> bool {
     keyfile_data.starts_with(b"$NACL")
 }
 
 /// Returns true if the keyfile data is ansible encrypted.
-#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
+#[cfg_attr(feature = "python-bindings", pyo3::pyfunction)]
 pub fn keyfile_data_is_encrypted_ansible(keyfile_data: &[u8]) -> bool {
     keyfile_data.starts_with(b"$ANSIBLE_VAULT")
 }
 
 /// Returns true if the keyfile data is legacy encrypted.
-#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
+#[cfg_attr(feature = "python-bindings", pyo3::pyfunction)]
 pub fn keyfile_data_is_encrypted_legacy(keyfile_data: &[u8]) -> bool {
     keyfile_data.starts_with(b"gAAAAA")
 }
 
 /// Returns `true` if the keyfile data is encrypted.
-#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
+#[cfg_attr(feature = "python-bindings", pyo3::pyfunction)]
 pub fn keyfile_data_is_encrypted(keyfile_data: &[u8]) -> bool {
     let nacl = keyfile_data_is_encrypted_nacl(keyfile_data);
     let ansible = keyfile_data_is_encrypted_ansible(keyfile_data);
@@ -190,7 +190,7 @@ pub fn keyfile_data_is_encrypted(keyfile_data: &[u8]) -> bool {
 }
 
 /// Returns type of encryption method as a string.
-#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
+#[cfg_attr(feature = "python-bindings", pyo3::pyfunction)]
 pub fn keyfile_data_encryption_method(keyfile_data: &[u8]) -> String {
     if keyfile_data_is_encrypted_nacl(keyfile_data) {
         "NaCl"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod constants;
 mod errors;
 mod keyfile;
 mod keypair;
-#[cfg(feature = "pyo3")]
+#[cfg(feature = "python-bindings")]
 mod python_bindings;
 mod utils;
 mod wallet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod constants;
 mod errors;
 mod keyfile;
 mod keypair;
+#[cfg(feature = "pyo3")]
 mod python_bindings;
 mod utils;
 mod wallet;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-use pyo3::pyfunction;
 use sp_core::crypto::{AccountId32, Ss58Codec};
 use std::str;
 
@@ -21,7 +20,7 @@ pub fn get_ss58_format(ss58_address: &str) -> Result<u16, &'static str> {
 ///
 /// Returns:
 ///     True if the address is a valid ss58 address for Bittensor, False otherwise.
-#[pyfunction]
+#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
 pub fn is_valid_ss58_address(address: &str) -> bool {
     if address.is_empty() {
         // Possibly there could be a debug log, but not a print
@@ -81,7 +80,7 @@ pub fn are_bytes_valid_ed25519_pubkey(public_key: &[u8]) -> bool {
 ///
 ///     Returns:
 ///         True if the address is a valid destination address, False otherwise.
-#[pyfunction]
+#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
 pub fn is_valid_bittensor_address_or_public_key(address: &str) -> bool {
     if address.starts_with("0x") {
         // Convert hex string to bytes
@@ -95,28 +94,23 @@ pub fn is_valid_bittensor_address_or_public_key(address: &str) -> bool {
     }
 }
 
-#[cfg(not(feature = "python-bindings"))]
+#[cfg(not(feature = "pyo3"))]
 pub fn print(s: String) {
     use std::io::{self, Write};
     print!("{}", s);
     io::stdout().flush().unwrap();
 }
 
-#[cfg(feature = "python-bindings")]
+#[cfg(feature = "pyo3")]
 pub fn print(s: String) {
-    pyo3::Python::with_gil(|py| {
-        let locals = PyDict::new_bound(py);
+    use pyo3::prelude::*;
+    use pyo3::types::{PyDict, PyDictMethods};
+    use std::ffi::CString;
+    Python::attach(|py| {
+        let locals = PyDict::new(py);
         locals.set_item("s", s).unwrap();
-        py.run_bound(
-            r#"
-import sys
-print(s, end='')
-sys.stdout.flush()
-"#,
-            None,
-            Some(&locals),
-        )
-        .unwrap();
+        let code = CString::new("import sys\nprint(s, end='')\nsys.stdout.flush()").unwrap();
+        py.run(&code, None, Some(&locals)).unwrap();
     });
 }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -10,7 +10,7 @@ use crate::keypair::Keypair;
 use crate::utils::{self, is_valid_bittensor_address_or_public_key};
 
 /// Display the mnemonic and a warning message to keep the mnemonic safe.
-#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
+#[cfg_attr(feature = "python-bindings", pyo3::pyfunction)]
 pub fn display_mnemonic_msg(mnemonic: String, key_type: &str) {
     utils::print(format!("{}", "\nIMPORTANT: Store this mnemonic in a secure (preferable offline place), as anyone who has possession of this mnemonic can use it to regenerate the key and access your tokens.\n".red()));
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,5 +1,4 @@
 use colored::Colorize;
-use pyo3::pyfunction;
 use std::path::PathBuf;
 use std::{env, fmt};
 
@@ -11,7 +10,7 @@ use crate::keypair::Keypair;
 use crate::utils::{self, is_valid_bittensor_address_or_public_key};
 
 /// Display the mnemonic and a warning message to keep the mnemonic safe.
-#[pyfunction]
+#[cfg_attr(feature = "pyo3", pyo3::pyfunction)]
 pub fn display_mnemonic_msg(mnemonic: String, key_type: &str) {
     utils::print(format!("{}", "\nIMPORTANT: Store this mnemonic in a secure (preferable offline place), as anyone who has possession of this mnemonic can use it to regenerate the key and access your tokens.\n".red()));
 


### PR DESCRIPTION
Previously, in order to use `btwallet` as a rust crate, the depending party needed to include python in their build environment because python bindings weren't an optional feature. This PR makes python bindings optional but default to preserve existing functionality but allow those who wish to use `btwallet` as a crate to avoid the unnecessary python build.