### PR TITLE
fix: consistent error handling for regenerate_hotkeypub and regenerate_coldkeypub

### DIFF
--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -1416,7 +1416,12 @@ except argparse.ArgumentError:
         let new_inner_wallet = self
             .inner
             .regenerate_coldkeypub(ss58_address, public_key, overwrite.unwrap_or(false))
-            .map_err(PyErr::new::<PyKeyFileError, _>)?;
+            .map_err(|e| match e {
+                WalletError::InvalidInput(_) | WalletError::KeyGeneration(_) => {
+                    PyErr::new::<PyValueError, _>(e.to_string())
+                }
+                _ => PyErr::new::<PyKeyFileError, _>(e.to_string()),
+            })?;
         self.inner = new_inner_wallet;
         Ok(Wallet {
             inner: self.inner.clone(),
@@ -1476,7 +1481,12 @@ except argparse.ArgumentError:
         let new_inner_wallet = self
             .inner
             .regenerate_hotkeypub(ss58_address, public_key, overwrite.unwrap_or(false))
-            .map_err(PyErr::new::<PyKeyFileError, _>)?;
+            .map_err(|e| match e {
+                WalletError::InvalidInput(_) | WalletError::KeyGeneration(_) => {
+                    PyErr::new::<PyValueError, _>(e.to_string())
+                }
+                _ => PyErr::new::<PyKeyFileError, _>(e.to_string()),
+            })?;
         self.inner = new_inner_wallet;
         Ok(Wallet {
             inner: self.inner.clone(),

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -171,3 +171,52 @@ def test_regenerate_hotkeypub(tmp_path):
     assert ss58_coldkey == ss58_coldkeypub
     assert ss58_hotkey == ss58_hotkeypub
     assert ss58_hotkeypub == new_ss58_hotkeypub
+
+
+def test_regenerate_hotkeypub_invalid_ss58(mock_wallet):
+    """Verify that regenerate_hotkeypub raises ValueError for invalid ss58_address."""
+    with pytest.raises(ValueError):
+        mock_wallet.regenerate_hotkeypub(
+            ss58_address="invalid_address", overwrite=True
+        )
+
+
+def test_regenerate_hotkeypub_no_args(mock_wallet):
+    """Verify that regenerate_hotkeypub raises ValueError when neither ss58 nor public_key is given."""
+    with pytest.raises(ValueError):
+        mock_wallet.regenerate_hotkeypub()
+
+
+def test_regenerate_coldkeypub_invalid_ss58(mock_wallet):
+    """Verify that regenerate_coldkeypub raises ValueError for invalid ss58_address."""
+    with pytest.raises(ValueError):
+        mock_wallet.regenerate_coldkeypub(
+            ss58_address="invalid_address", overwrite=True
+        )
+
+
+def test_regenerate_coldkeypub_no_args(mock_wallet):
+    """Verify that regenerate_coldkeypub raises ValueError when neither ss58 nor public_key is given."""
+    with pytest.raises(ValueError):
+        mock_wallet.regenerate_coldkeypub()
+
+
+def test_regenerate_hotkeypub_with_public_key(tmp_path):
+    """Verify that regenerate_hotkeypub works with public_key parameter."""
+    wallet_path = (tmp_path / "test_wallets").resolve().as_posix()
+    w = Wallet(name="test_wallet", hotkey="test_hotkey", path=wallet_path)
+    w.create(coldkey_use_password=False)
+
+    public_key = w.hotkey.public_key
+    w.regenerate_hotkeypub(public_key=public_key, overwrite=True)
+
+    assert w.hotkeypub.public_key == public_key
+
+
+def test_hotkeypub_file_not_found(tmp_path):
+    """Verify that accessing hotkeypub raises KeyFileError when file does not exist."""
+    wallet_path = (tmp_path / "test_wallets").resolve().as_posix()
+    w = Wallet(name="test_wallet", hotkey="test_hotkey", path=wallet_path)
+
+    with pytest.raises(KeyFileError):
+        _ = w.hotkeypub


### PR DESCRIPTION
## Summary

- `regenerate_hotkeypub()` and `regenerate_coldkeypub()` Python bindings now raise `ValueError` for invalid inputs (matching `regenerate_coldkey()` behavior) instead of generic `KeyFileError`
- Added 6 tests covering edge cases: invalid ss58 address, missing args, public_key parameter, and file-not-found scenarios

## Problem

`regenerate_coldkey()` correctly maps `WalletError::InvalidInput` and `WalletError::KeyGeneration` to `PyValueError`, but `regenerate_hotkeypub()` and `regenerate_coldkeypub()` mapped all errors generically to `PyKeyFileError`. This means callers catching `ValueError` for input validation would miss errors from these two methods.

## Changes

**`src/python_bindings.rs`:**
- `regenerate_coldkeypub()`: replaced generic `.map_err(PyErr::new::<PyKeyFileError, _>)` with match on `InvalidInput`/`KeyGeneration` → `PyValueError`, other → `PyKeyFileError`
- `regenerate_hotkeypub()`: same fix

**`tests/test_wallet.py`:**
- `test_regenerate_hotkeypub_invalid_ss58` — invalid address raises ValueError
- `test_regenerate_hotkeypub_no_args` — no ss58 or public_key raises ValueError
- `test_regenerate_coldkeypub_invalid_ss58` — same for coldkeypub
- `test_regenerate_coldkeypub_no_args` — same for coldkeypub
- `test_regenerate_hotkeypub_with_public_key` — regenerate via public_key works
- `test_hotkeypub_file_not_found` — accessing hotkeypub without file raises KeyFileError

Closes #155