### PR TITLE
fix: use PBKDF2-derived key for legacy Fernet decryption

### DIFF
--- a/src/keyfile.rs
+++ b/src/keyfile.rs
@@ -305,8 +305,9 @@ pub fn decrypt_keyfile_data(
         let mut key = vec![0; 32];
         kdf(password.as_bytes(), LEGACY_SALT, 10000000, &mut key);
 
-        let fernet_key = Fernet::generate_key();
-        let fernet = Fernet::new(&fernet_key).unwrap();
+        let fernet_key = general_purpose::URL_SAFE.encode(&key);
+        let fernet = Fernet::new(&fernet_key)
+            .ok_or_else(|| KeyFileError::Generic("Invalid fernet key".into()))?;
         let keyfile_data_str = from_utf8(keyfile_data)
             .map_err(|e| KeyFileError::DeserializationError(e.to_string()))?;
         fernet.decrypt(keyfile_data_str).map_err(|_| {


### PR DESCRIPTION
## Summary

Fixes #185

`legacy_decrypt` derives a key from the user's password via PBKDF2 (line 304-306) but then completely ignores it. It calls `Fernet::generate_key()` which creates a random key, making decryption always fail regardless of the correct password.

## Changes

**`src/keyfile.rs`**: Replace `Fernet::generate_key()` with URL-safe base64 encoding of the PBKDF2-derived key bytes, constructing a valid Fernet key that matches the Python `cryptography` library's format used by the original bittensor wallet.

## Impact

Without this fix, legacy-encrypted keyfiles cannot be decrypted through the Rust wallet implementation. Users migrating from the Python wallet would be unable to access their funds.