### PR TITLE
Complete pub-fn docstring coverage on keypair, utils, wallet

### DIFF
--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -358,15 +358,19 @@ impl Keypair {
             data
         }
 
-        /// Builds an SR25519 (secret, public) byte tuple from raw Ed25519 key material.
+        /// Builds an SR25519 (secret, public) byte tuple. The secret is converted
+        /// from raw Ed25519 form; the public key is already SR25519 (Ristretto)
+        /// and is passed through as-is.
         ///
+        /// ```text
         ///     Arguments:
-        ///         secret (&[u8]): The Ed25519 private key bytes.
-        ///         pubkey (&[u8]): The matching Ed25519 public key bytes.
+        ///         secret (&[u8]): The Ed25519 private key bytes to convert to SR25519.
+        ///         pubkey (&[u8]): The SR25519 (Ristretto-compressed) public key bytes.
         ///     Returns:
-        ///         pair ([u8; 64], [u8; 32]): A tuple of the 64-byte secret key and 32-byte public key.
+        ///         pair ([u8; 64], [u8; 32]): A tuple of the 64-byte secret and 32-byte public key.
         ///     Panics:
         ///         If either input cannot be parsed by ``schnorrkel``.
+        /// ```
         pub fn pair_from_ed25519_secret_key(secret: &[u8], pubkey: &[u8]) -> ([u8; 64], [u8; 32]) {
             match (
                 SecretKey::from_ed25519_bytes(secret),

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -358,6 +358,15 @@ impl Keypair {
             data
         }
 
+        /// Builds an SR25519 (secret, public) byte tuple from raw Ed25519 key material.
+        ///
+        ///     Arguments:
+        ///         secret (&[u8]): The Ed25519 private key bytes.
+        ///         pubkey (&[u8]): The matching Ed25519 public key bytes.
+        ///     Returns:
+        ///         pair ([u8; 64], [u8; 32]): A tuple of the 64-byte secret key and 32-byte public key.
+        ///     Panics:
+        ///         If either input cannot be parsed by ``schnorrkel``.
         pub fn pair_from_ed25519_secret_key(secret: &[u8], pubkey: &[u8]) -> ([u8; 64], [u8; 32]) {
             match (
                 SecretKey::from_ed25519_bytes(secret),
@@ -629,6 +638,7 @@ impl Keypair {
         self.ss58_format
     }
 
+    /// Returns the seed bytes used to derive this keypair, if known.
     pub fn seed_hex(&self) -> Option<Vec<u8>> {
         self.seed_hex.clone()
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -113,6 +113,11 @@ pub fn print(s: String) {
     io::stdout().flush().unwrap();
 }
 
+/// Writes `s` through Python's `sys.stdout` so the output stays interleaved with
+/// Python-level I/O (Jupyter cells, logging redirects, captured stdout, etc.).
+///
+///     Arguments:
+///         s (String): The text to print.
 #[cfg(feature = "python-bindings")]
 pub fn print(s: String) {
     use pyo3::types::{PyDict, PyDictMethods};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -116,8 +116,10 @@ pub fn print(s: String) {
 /// Writes `s` through Python's `sys.stdout` so the output stays interleaved with
 /// Python-level I/O (Jupyter cells, logging redirects, captured stdout, etc.).
 ///
+/// ```text
 ///     Arguments:
 ///         s (String): The text to print.
+/// ```
 #[cfg(feature = "python-bindings")]
 pub fn print(s: String) {
     use pyo3::types::{PyDict, PyDictMethods};

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -125,11 +125,13 @@ impl Wallet {
     /// arguments on the given clap command, seeded from the `BT_WALLET_NAME`,
     /// `BT_WALLET_HOTKEY`, and `BT_WALLET_PATH` environment variables when set.
     ///
+    /// ```text
     ///     Arguments:
     ///         parser (clap::Command): The clap command to extend.
     ///         _prefix (Option<&str>): Reserved for future argument-prefix support (see inline TODO).
     ///     Returns:
     ///         parser (clap::Command): The same command with the wallet arguments added.
+    /// ```
     // TODO: What are the prefixes for ?
     pub fn add_args(parser: clap::Command, _prefix: Option<&str>) -> clap::Command {
         let default_name =

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -121,6 +121,15 @@ impl Wallet {
         unimplemented!()
     }
 
+    /// Registers the wallet's `--wallet.name`, `--wallet.hotkey`, and `--wallet.path`
+    /// arguments on the given clap command, seeded from the `BT_WALLET_NAME`,
+    /// `BT_WALLET_HOTKEY`, and `BT_WALLET_PATH` environment variables when set.
+    ///
+    ///     Arguments:
+    ///         parser (clap::Command): The clap command to extend.
+    ///         _prefix (Option<&str>): Reserved for future argument-prefix support (see inline TODO).
+    ///     Returns:
+    ///         parser (clap::Command): The same command with the wallet arguments added.
     // TODO: What are the prefixes for ?
     pub fn add_args(parser: clap::Command, _prefix: Option<&str>) -> clap::Command {
         let default_name =


### PR DESCRIPTION
## Summary

Follow-up to #170 (chideraao, "updated docstrings"), which added the
indented Arguments/Returns/Raises docstring style to most of the
public API on this crate. Four `pub fn`s were missed in that pass;
this PR fills them in using the same format so `cargo doc` output —
and any downstream docs-generation tooling that #170 was preparing
for — ends up complete.

## What changed

- `src/keypair.rs::pair_from_ed25519_secret_key` — documents the Ed25519-to-SR25519 byte conversion and notes the `panic!` path on invalid input.
- `src/keypair.rs::Keypair::seed_hex` — one-line summary for the seed-bytes getter, matching the style of the adjacent
  `ss58_format`/`crypto_type` getters that #170 already documented.
- `src/utils.rs::print` (python-bindings variant) — documents why this `#[cfg(feature = "python-bindings")]` variant routes through Python's `sys.stdout` instead of native Rust stdout. The sibling non-python-bindings variant on the line above is already documented; this brings parity.
- `src/wallet.rs::Wallet::add_args` — documents the clap arguments registered (`--wallet.name`, `--wallet.hotkey`, `--wallet.path`)
  and the `BT_WALLET_*` env-variable defaults. The existing `// TODO: What are the prefixes for ?` comment is preserved verbatim.

## Coverage

Static scan of `pub fn` items vs. preceding `///` doc-blocks (skipping `#[cfg]`/`#[derive]` attributes and blank lines) across `src/`:

| File | Before | After |
|---|---|---|
| `config.rs` | 5/5 | 5/5 |
| `keyfile.rs` | 34/34 | 34/34 |
| `keypair.rs` | 16/18 | 18/18 |
| `python_bindings.rs` | 3/3 | 3/3 |
| `utils.rs` | 8/9 | 9/9 |
| `wallet.rs` | 41/42 | 42/42 |

## Verification
