### PR TITLE
Point docs at bittensor.com/docs and surface the supersession notice on PyPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "btwallet"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "ansible-vault",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btwallet"
-version = "4.1.0"
+version = "4.1.1"
 edition = "2021"
 license = "MIT"
 description = "Bittensor wallet — Substrate-based key management, encryption, and signing."

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-> [!IMPORTANT]
-> **This repository is archived and no longer maintained.**
->
-> `bittensor_wallet` is superseded by `bittensor.wallet` in Bittensor 11, developed in the [subtensor monorepo](https://github.com/RaoFoundation/subtensor). The on-disk keyfile format is unchanged — existing wallets work as-is. Existing releases remain installable from PyPI.
+# ⚠️ This package is superseded
+
+**`bittensor-wallet` is superseded by the [`bittensor`](https://pypi.org/project/bittensor/) package (Bittensor 11), where the wallet ships as `bittensor.wallet`.** New projects should `pip install bittensor` instead. Development happens in the [subtensor monorepo](https://github.com/RaoFoundation/subtensor), and documentation lives at [bittensor.com/docs](https://bittensor.com/docs).
+
+The on-disk keyfile format is unchanged — existing wallets work as-is. Existing `bittensor-wallet` releases remain installable from PyPI, but this repository is no longer maintained and no further feature releases will be cut from it.
+
+---
 
 <div align="center">
 
@@ -49,7 +52,7 @@ For instructions on setting up GPG key signing, see [GitHub's documentation on s
 
 ## Documentation
 
-For a full documentation on how to use `btwallet`, see the [Bittensor Wallet SDK section](https://docs.bittensor.com/working-with-keys) on the developer documentation site.
+For full documentation, see [bittensor.com/docs](https://bittensor.com/docs).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ classifiers = [
 
 [project.urls]
 Repository = "https://github.com/opentensor/btwallet"
+Documentation = "https://bittensor.com/docs"
+Superseded-by = "https://pypi.org/project/bittensor/"
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]


### PR DESCRIPTION
## Summary
- The PyPI page for `bittensor-wallet` (ranks highly in search) has no indication the package is superseded: the notice landed after 4.1.0 shipped and uses GitHub-only `[!IMPORTANT]` alert syntax that PyPI renders as literal text. Rewritten in plain markdown with links to the `bittensor` package and bittensor.com/docs.
- `docs.bittensor.com` no longer resolves; the Documentation section now points at https://bittensor.com/docs (also added to `[project.urls]`).
- Version bumped to 4.1.1 (Cargo.toml + Cargo.lock; pyproject version is dynamic from Cargo) so a release can carry the new description to PyPI.

## Test plan
- [ ] Merge, dispatch `release.yml` with `publish_target=pypi-only`, confirm https://pypi.org/project/bittensor-wallet/ shows the supersession notice.

Made with [Cursor](https://cursor.com)